### PR TITLE
Add ADST modeling modules (single-site + city-level)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ SWEET_python.egg-info/
 build/
 SWEET_python/unused
 SWEET_python.egg-info
+
+# Local Claude Code project instructions (not shared)
+/CLAUDE.md

--- a/SWEET_python/advanced_dst.py
+++ b/SWEET_python/advanced_dst.py
@@ -4,87 +4,40 @@ Advanced DST (adst) — single-site methane modeling.
 This is the modeling backend for the ``/v1/site_emissions/adst`` endpoint. It is
 the "advanced" successor to ``City.sdst_v1_5``, but deliberately much simpler:
 the caller supplies waste mass and composition directly as time series, so this
-module does *no* waste generation, population growth, or TRACE reconciliation.
-It just turns the supplied numbers into a baseline and a scenario emissions
-time series.
+module does *no* waste generation, population growth, diversion accounting, or
+TRACE reconciliation. It just turns the supplied numbers into a baseline and a
+scenario emissions time series for a single landfill.
+
+For the multi-landfill, diversion-aware city version, see ``advanced_dst_city``.
+Shared plumbing lives in ``dst_common``.
 
 Design notes
 ------------
 * Inputs arrive as :class:`SWEET_python.class_defs.Variant` objects carrying a
-  ``baseline`` and an optional ``scenario`` value. When ``scenario`` is omitted
-  it falls back to ``baseline``.
+  ``baseline`` and an optional ``scenario`` value (which falls back to baseline).
 * The scenario variant equals the baseline variant for every year before
   ``implement_year`` and switches to the scenario inputs from ``implement_year``
   onward — the same convention the rest of the SWEET model uses.
 * ``run_advanced_dst`` is a pure function: it returns the result and never
   mutates shared state. It builds a throwaway :class:`City`/:class:`Landfill`
-  internally purely to reuse the tested emission engine and summation logic.
-* Eventually this module is meant to grow to handle whole-city, multi-site, and
-  diversion modeling together; for now it handles one site at a time.
+  internally purely to reuse the tested emission engine.
+* Here ``waste_mass`` is the final landfilled mass (no diversion). The city-level
+  endpoint instead treats ``waste_mass`` as total generated waste and subtracts
+  diversions.
 """
 
-from types import SimpleNamespace
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
-import numpy as np
 import pandas as pd
 from pydantic import BaseModel, Field
 
 import SWEET_python.defaults_2019 as defaults_2019
-from SWEET_python.city_params import City, CityParameters, CustomError
-from SWEET_python.class_defs import DecompositionRates, Fraction, LandfillType, Variant
-from SWEET_python.landfill import Landfill
-from SWEET_python.singapore_k import compute_singapore_k
+from SWEET_python.city_params import City, CityParameters
+from SWEET_python.class_defs import LandfillType, Variant
+from SWEET_python import dst_common as common
+from SWEET_python.dst_common import YearlyFloat, YearlyFractions
 
 __all__ = ["AdvancedDSTRequest", "run_advanced_dst"]
-
-# The model is only ever evaluated over this window. Open years are validated
-# against MODEL_YEAR_MIN to avoid accidental giant simulations.
-MODEL_YEAR_MIN = 1950
-MODEL_YEAR_MAX = 2050
-
-# Order matters: waste_fractions vectors are sent in this column order.
-WASTE_COMPONENTS: List[str] = [
-    "food",
-    "green",
-    "wood",
-    "paper_cardboard",
-    "textiles",
-    "plastic",
-    "metal",
-    "glass",
-    "rubber",
-    "other",
-]
-# The SWEET engine only generates methane from the biodegradable components
-# (these are the components that have a k value and an L_0).
-DEGRADABLE_COMPONENTS: List[str] = [
-    "food",
-    "green",
-    "wood",
-    "paper_cardboard",
-    "textiles",
-]
-
-# Methane correction factor by landfill type (index == LandfillType value).
-# 0 landfill, 1 controlled dump, 2 open dump.
-MCF_BY_TYPE: List[float] = [1.0, 0.6, 0.4]
-SITE_TYPE_NAMES: List[str] = ["landfill", "controlled_dumpsite", "dumpsite"]
-
-# Oxidation factor lookup, mirroring City.sdst_v1_5 / Landfill.estimate_emissions.
-OX_NOCAP: Dict[str, float] = {"landfill": 0.1, "controlled_dumpsite": 0.05, "dumpsite": 0.0}
-OX_CAP: Dict[str, float] = {"landfill": 0.22, "controlled_dumpsite": 0.1, "dumpsite": 0.0}
-# A dump that is upgraded ("ameliorated") to an engineered landfill with gas
-# capture gets a higher oxidation factor than a landfill that always existed.
-OX_REMEDIATED_TO_LANDFILL = 0.18
-
-DEFAULT_FLARE_EFFICIENCY = 0.98
-
-
-# A yearly time series arrives over the wire as {year: value}. Pydantic coerces
-# JSON string keys ("2025") to ints.
-YearlyFloat = Dict[int, float]
-YearlyFractions = Dict[int, List[float]]
 
 
 class AdvancedDSTRequest(BaseModel):
@@ -111,7 +64,7 @@ class AdvancedDSTRequest(BaseModel):
     landfill_type: Variant[LandfillType] = Field(
         ..., description="Site type: 0 landfill, 1 controlled dump, 2 open dump."
     )
-    landfill_open_close: Variant[Tuple[int, int]] = Field(
+    landfill_open_close: Variant[tuple[int, int]] = Field(
         ..., description="(open_year, close_year) of the site."
     )
     gas_capture_efficiency: Variant[YearlyFloat] = Field(
@@ -130,202 +83,11 @@ class AdvancedDSTRequest(BaseModel):
     rmi_id: Optional[int] = Field(None, description="Site identifier. Stored for identity.")
 
 
-# --------------------------------------------------------------------------- #
-# Input -> time series helpers
-# --------------------------------------------------------------------------- #
-def _variant_get(variant: Optional[Variant], label: str):
-    """Return ``variant[label]`` with a graceful fallback to baseline."""
-    if variant is None:
-        return None
-    value = variant[label]
-    if value is None and label == "scenario":
-        return variant["baseline"]
-    return value
-
-
-def _yearly_to_series(
-    mapping: Optional[Dict[int, float]],
-    years: pd.Index,
-    default: Optional[float] = None,
-) -> pd.Series:
-    """Turn a ``{year: value}`` map into a series aligned to ``years``.
-
-    Missing interior years are forward/back filled. When ``mapping`` is empty a
-    ``default`` is required, otherwise we raise rather than silently model zeros.
-    """
-    if not mapping:
-        if default is None:
-            raise CustomError("invalid_parameters", "Missing required yearly time series.")
-        return pd.Series(float(default), index=years)
-    series = pd.Series({int(k): float(v) for k, v in mapping.items()})
-    series = series.sort_index().reindex(years).ffill().bfill()
-    if default is not None:
-        series = series.fillna(float(default))
-    return series
-
-
-def _fractions_to_df(mapping: Optional[Dict[int, List[float]]], years: pd.Index) -> pd.DataFrame:
-    """Turn a ``{year: [10 fractions]}`` map into a years x components frame."""
-    if not mapping:
-        raise CustomError("invalid_parameters", "Missing waste_fractions time series.")
-    rows: Dict[int, List[float]] = {}
-    for year, vector in mapping.items():
-        if len(vector) != len(WASTE_COMPONENTS):
-            raise CustomError(
-                "invalid_parameters",
-                f"waste_fractions for year {year} must have {len(WASTE_COMPONENTS)} values.",
-            )
-        rows[int(year)] = [float(x) for x in vector]
-    frame = pd.DataFrame.from_dict(rows, orient="index", columns=WASTE_COMPONENTS)
-    return frame.sort_index().reindex(years).ffill().bfill()
-
-
-def _variant_series(
-    variant: Optional[Variant],
-    years: pd.Index,
-    implement_year: int,
-    default: Optional[float],
-) -> Tuple[pd.Series, pd.Series]:
-    """Build (baseline_series, scenario_series) for a yearly Variant input.
-
-    The scenario series equals baseline before ``implement_year`` and switches to
-    the scenario inputs from ``implement_year`` onward.
-    """
-    baseline_map = _variant_get(variant, "baseline") if variant is not None else None
-    baseline = _yearly_to_series(baseline_map, years, default=default)
-
-    scenario_map = variant["scenario"] if variant is not None else None
-    if scenario_map is None:
-        return baseline, baseline.copy()
-
-    scenario_input = _yearly_to_series(scenario_map, years, default=default)
-    scenario = baseline.copy()
-    scenario.loc[implement_year:] = scenario_input.loc[implement_year:]
-    return baseline, scenario
-
-
-def _apply_window(mass_df: pd.DataFrame, open_year: int, close_year: int) -> pd.DataFrame:
-    """Zero out waste deposited before the site opens or after it closes."""
-    windowed = mass_df.copy()
-    windowed.loc[: int(open_year) - 1, :] = 0.0
-    windowed.loc[int(close_year):, :] = 0.0
-    return windowed
-
-
-# --------------------------------------------------------------------------- #
-# Model parameter construction
-# --------------------------------------------------------------------------- #
-def _representative_vector(fractions_df: pd.DataFrame, ref_year: int) -> SimpleNamespace:
-    """A single composition vector used for the k-value lookup.
-
-    The Wang et al. (2024) k method maps a composition to a single rate via a
-    coarse 8x8x8 lookup, and the existing ``advanced_dst`` path takes one vector
-    per scenario. We sample the composition at ``ref_year`` (the implement year),
-    matching the granularity of the rest of the scenario switch.
-    """
-    row = fractions_df.loc[ref_year]
-    return SimpleNamespace(**{component: float(row[component]) for component in WASTE_COMPONENTS})
-
-
-def _reindex_decomp(ks: DecompositionRates, years: pd.Index) -> DecompositionRates:
-    """compute_singapore_k returns 1990..2050 series; align them to model years."""
-
-    def fix(series: pd.Series) -> pd.Series:
-        return series.reindex(years).ffill().bfill()
-
-    return DecompositionRates(
-        food=fix(ks.food),
-        green=fix(ks.green),
-        wood=fix(ks.wood),
-        paper_cardboard=fix(ks.paper_cardboard),
-        textiles=fix(ks.textiles),
-    )
-
-
-def _decomposition_rates(
-    temperature: float,
-    precipitation: float,
-    implement_year: int,
-    years: pd.Index,
-    baseline_vector: SimpleNamespace,
-    scenario_vector: SimpleNamespace,
-) -> Tuple[DecompositionRates, DecompositionRates]:
-    """Per-variant decomposition rates (Wang et al. 2024).
-
-    The baseline landfill keeps baseline composition for all years, so its k is
-    constant. The scenario landfill uses baseline k before ``implement_year`` and
-    scenario k after, which ``compute_singapore_k(advanced_dst=True)`` produces.
-    """
-    baseline_only = {"baseline": baseline_vector, "scenario": baseline_vector}
-    scenario_mix = {"baseline": baseline_vector, "scenario": scenario_vector}
-
-    ks_baseline, _ = compute_singapore_k(
-        baseline_only, temperature, precipitation,
-        advanced_dst=True, implement_year=implement_year,
-    )
-    ks_scenario, _ = compute_singapore_k(
-        scenario_mix, temperature, precipitation,
-        advanced_dst=True, implement_year=implement_year,
-    )
-    return _reindex_decomp(ks_baseline, years), _reindex_decomp(ks_scenario, years)
-
-
-def _oxidation_series(
-    baseline_type: int,
-    scenario_type: int,
-    gas_capture: pd.Series,
-    biocover: pd.Series,
-    implement_year: int,
-    years: pd.Index,
-) -> pd.Series:
-    """Per-year oxidation factor.
-
-    Before ``implement_year`` the site is ``baseline_type``; after, it is
-    ``scenario_type``. For each year, gas capture (efficiency > 0) selects the
-    capped vs uncapped oxidation factor. A dump upgraded to an engineered
-    landfill with capture gets the higher remediated factor. The biocover series
-    acts as a floor.
-    """
-    baseline_name = SITE_TYPE_NAMES[baseline_type]
-    scenario_name = SITE_TYPE_NAMES[scenario_type]
-    ameliorated = scenario_type < baseline_type
-
-    values = []
-    for year in years:
-        has_capture = float(gas_capture.loc[year]) > 0
-        if year < implement_year:
-            value = OX_CAP[baseline_name] if has_capture else OX_NOCAP[baseline_name]
-        elif has_capture:
-            if ameliorated and scenario_type == LandfillType.landfill.value:
-                value = OX_REMEDIATED_TO_LANDFILL
-            else:
-                value = OX_CAP[scenario_name]
-        else:
-            value = OX_NOCAP[scenario_name]
-        values.append(max(value, float(biocover.loc[year])))
-    return pd.Series(values, index=years, dtype=float)
-
-
-def _city_instance_attrs(city: City, country: Optional[str]) -> Dict:
-    """The slice of City config the engine reads (notably ``components``)."""
-    return {
-        "city_name": city.city_name,
-        "country": country,
-        "components": city.components,
-        "div_components": city.div_components,
-        "waste_types": city.waste_types,
-        "unprocessable": city.unprocessable,
-        "non_compostable_not_targeted": city.non_compostable_not_targeted,
-        "combustion_reject_rate": city.combustion_reject_rate,
-        "recycling_reject_rates": city.recycling_reject_rates,
-    }
-
-
 def _make_parameters(
     request: AdvancedDSTRequest,
     fractions_df: pd.DataFrame,
-    ks: DecompositionRates,
-    city_instance_attrs: Dict,
+    ks,
+    city_instance_attrs: dict,
     implement_year: int,
     scenario: int,
 ) -> CityParameters:
@@ -351,45 +113,11 @@ def _make_parameters(
     )
 
 
-# --------------------------------------------------------------------------- #
-# Validation
-# --------------------------------------------------------------------------- #
-def _validate(open_close_pairs: List[Tuple[int, int]], implement_year: int) -> int:
-    """Validate site dates and the implement year. Returns the model start year."""
-    open_years = []
-    for open_year, close_year in open_close_pairs:
-        open_year, close_year = int(open_year), int(close_year)
-        if not (MODEL_YEAR_MIN <= open_year <= MODEL_YEAR_MAX):
-            raise CustomError(
-                "invalid_year",
-                f"Landfill open year must be between {MODEL_YEAR_MIN} and {MODEL_YEAR_MAX} (got {open_year}).",
-            )
-        if not (MODEL_YEAR_MIN <= close_year <= MODEL_YEAR_MAX):
-            raise CustomError(
-                "invalid_year",
-                f"Landfill close year must be between {MODEL_YEAR_MIN} and {MODEL_YEAR_MAX} (got {close_year}).",
-            )
-        if close_year < open_year:
-            raise CustomError("invalid_year", "Landfill close year must be on or after open year.")
-        open_years.append(open_year)
-
-    model_start = min(open_years)
-    if not (model_start <= int(implement_year) <= MODEL_YEAR_MAX):
-        raise CustomError(
-            "invalid_year",
-            f"implement_year must be between {model_start} and {MODEL_YEAR_MAX} (got {implement_year}).",
-        )
-    return model_start
-
-
-# --------------------------------------------------------------------------- #
-# Public entry point
-# --------------------------------------------------------------------------- #
-def run_advanced_dst(request: AdvancedDSTRequest) -> Dict[str, pd.DataFrame]:
+def run_advanced_dst(request: AdvancedDSTRequest) -> dict[str, pd.DataFrame]:
     """Run the advanced single-site DST.
 
     Returns ``{"baseline": total_emissions_df, "scenario": total_emissions_df}``
-    where each frame is indexed by year with a ``total`` column (tons CO2e).
+    where each frame is indexed by year with a ``total`` column.
     """
     implement_year = int(request.implement_year)
 
@@ -397,92 +125,70 @@ def run_advanced_dst(request: AdvancedDSTRequest) -> Dict[str, pd.DataFrame]:
     scenario_dates = request.landfill_open_close["scenario"] or request.landfill_open_close["baseline"]
     scenario_open, scenario_close = (int(x) for x in scenario_dates)
 
-    model_start = _validate(
+    model_start = common.validate_years(
         [(baseline_open, baseline_close), (scenario_open, scenario_close)],
         implement_year,
     )
-    years = pd.Index(range(model_start, MODEL_YEAR_MAX + 1), name="year")
+    years = pd.Index(range(model_start, common.MODEL_YEAR_MAX + 1), name="year")
 
     # --- Waste mass by component (fractions x total), per variant ---
-    baseline_fractions = _fractions_to_df(request.waste_fractions["baseline"], years)
-    scenario_fractions = _fractions_to_df(
+    baseline_fractions = common.fractions_to_df(request.waste_fractions["baseline"], years)
+    scenario_fractions = common.fractions_to_df(
         request.waste_fractions["scenario"] or request.waste_fractions["baseline"], years
     )
-    baseline_total, scenario_total = _variant_series(request.waste_mass, years, implement_year, default=None)
+    baseline_total, scenario_total = common.variant_series(request.waste_mass, years, implement_year, default=None)
 
     baseline_mass = baseline_fractions.mul(baseline_total, axis=0)
     scenario_mass = scenario_fractions.mul(scenario_total, axis=0)
-    # Scenario tracks baseline before changes take effect.
     scenario_mass.loc[: implement_year - 1, :] = baseline_mass.loc[: implement_year - 1, :]
-    baseline_mass = _apply_window(baseline_mass, baseline_open, baseline_close)
-    scenario_mass = _apply_window(scenario_mass, scenario_open, scenario_close)
+    baseline_mass = common.apply_window(baseline_mass, baseline_open, baseline_close)
+    scenario_mass = common.apply_window(scenario_mass, scenario_open, scenario_close)
 
     # --- Decomposition rates ---
     ref_year = min(max(implement_year, int(years.min())), int(years.max()))
-    ks_baseline, ks_scenario = _decomposition_rates(
+    ks_baseline, ks_scenario = common.decomposition_rates(
         request.temperature,
         request.precipitation,
         implement_year,
         years,
-        _representative_vector(baseline_fractions, ref_year),
-        _representative_vector(scenario_fractions, ref_year),
+        common.representative_vector(baseline_fractions, ref_year),
+        common.representative_vector(scenario_fractions, ref_year),
     )
 
     # --- MCF / gas capture / flaring / oxidation series ---
     baseline_type = int(request.landfill_type["baseline"])
     scenario_type = int(request.landfill_type["scenario"]) if request.landfill_type["scenario"] is not None else baseline_type
 
-    mcf_baseline = pd.Series(MCF_BY_TYPE[baseline_type], index=years, dtype=float)
-    mcf_scenario = mcf_baseline.copy()
-    mcf_scenario.loc[implement_year:] = MCF_BY_TYPE[scenario_type]
+    mcf_baseline = common.mcf_series(baseline_type, baseline_type, implement_year, years)
+    mcf_scenario = common.mcf_series(baseline_type, scenario_type, implement_year, years)
 
-    gas_baseline, gas_scenario = _variant_series(request.gas_capture_efficiency, years, implement_year, default=0.0)
-    flare_baseline, flare_scenario = _variant_series(request.flaring, years, implement_year, default=DEFAULT_FLARE_EFFICIENCY)
-    biocover_baseline, biocover_scenario = _variant_series(request.biocover, years, implement_year, default=0.0)
+    gas_baseline, gas_scenario = common.variant_series(request.gas_capture_efficiency, years, implement_year, default=0.0)
+    flare_baseline, flare_scenario = common.variant_series(request.flaring, years, implement_year, default=common.DEFAULT_FLARE_EFFICIENCY)
+    biocover_baseline, biocover_scenario = common.variant_series(request.biocover, years, implement_year, default=0.0)
 
-    ox_baseline = _oxidation_series(baseline_type, baseline_type, gas_baseline, biocover_baseline, implement_year, years)
-    ox_scenario = _oxidation_series(baseline_type, scenario_type, gas_scenario, biocover_scenario, implement_year, years)
+    ox_baseline = common.oxidation_series(baseline_type, baseline_type, gas_baseline, biocover_baseline, implement_year, years)
+    ox_scenario = common.oxidation_series(baseline_type, scenario_type, gas_scenario, biocover_scenario, implement_year, years)
 
     # --- Assemble city / landfills and run the engine ---
     city = City("advanced_dst_site")
-    city_instance_attrs = _city_instance_attrs(city, request.country)
+    city_instance_attrs = common.city_instance_attrs(city, request.country)
 
     baseline_parameters = _make_parameters(request, baseline_fractions, ks_baseline, city_instance_attrs, implement_year, 0)
     scenario_parameters = _make_parameters(request, scenario_fractions, ks_scenario, city_instance_attrs, implement_year, 1)
 
-    baseline_landfill = Landfill(
-        open_date=baseline_open,
-        close_date=baseline_close,
-        site_type=SITE_TYPE_NAMES[baseline_type],
-        mcf=mcf_baseline,
+    baseline_landfill = common.build_landfill(
+        open_year=baseline_open, close_year=baseline_close, site_type_idx=baseline_type,
+        mcf=mcf_baseline, gas_capture_efficiency=gas_baseline, flaring=flare_baseline,
+        oxidation_factor=ox_baseline, ks=ks_baseline,
         city_params_dict=baseline_parameters.update_cityparams_dict(),
-        city_instance_attrs=city_instance_attrs,
-        landfill_index=0,
-        gas_capture=bool((gas_baseline > 0).any()),
-        gas_capture_efficiency=gas_baseline,
-        flaring=flare_baseline,
-        oxidation_factor=ox_baseline,
-        ks=ks_baseline,
-        advanced=True,
-        implementation_year=implement_year,
-        scenario=0,
+        city_instance_attrs=city_instance_attrs, implement_year=implement_year, scenario=0,
     )
-    scenario_landfill = Landfill(
-        open_date=scenario_open,
-        close_date=scenario_close,
-        site_type=SITE_TYPE_NAMES[scenario_type],
-        mcf=mcf_scenario,
+    scenario_landfill = common.build_landfill(
+        open_year=scenario_open, close_year=scenario_close, site_type_idx=scenario_type,
+        mcf=mcf_scenario, gas_capture_efficiency=gas_scenario, flaring=flare_scenario,
+        oxidation_factor=ox_scenario, ks=ks_scenario,
         city_params_dict=scenario_parameters.update_cityparams_dict(),
-        city_instance_attrs=city_instance_attrs,
-        landfill_index=0,
-        gas_capture=bool((gas_scenario > 0).any()),
-        gas_capture_efficiency=gas_scenario,
-        flaring=flare_scenario,
-        oxidation_factor=ox_scenario,
-        ks=ks_scenario,
-        advanced=True,
-        implementation_year=implement_year,
-        scenario=1,
+        city_instance_attrs=city_instance_attrs, implement_year=implement_year, scenario=1,
     )
 
     baseline_parameters.landfills = [baseline_landfill]
@@ -498,10 +204,10 @@ def run_advanced_dst(request: AdvancedDSTRequest) -> Dict[str, pd.DataFrame]:
     baseline_landfill.estimate_emissions(skip_ox=True)
     scenario_landfill.estimate_emissions(skip_ox=True)
 
-    # No diversion in the advanced single-site DST: the supplied mass is the
-    # final landfilled mass, so there are no organic (compost/anaerobic) emissions.
-    baseline_parameters.organic_emissions = pd.DataFrame(0.0, index=years, columns=DEGRADABLE_COMPONENTS)
-    scenario_parameters.organic_emissions = pd.DataFrame(0.0, index=years, columns=DEGRADABLE_COMPONENTS)
+    # No diversion in the single-site DST: the supplied mass is the final
+    # landfilled mass, so there are no organic (compost/anaerobic) emissions.
+    baseline_parameters.organic_emissions = pd.DataFrame(0.0, index=years, columns=common.DEGRADABLE_COMPONENTS)
+    scenario_parameters.organic_emissions = pd.DataFrame(0.0, index=years, columns=common.DEGRADABLE_COMPONENTS)
 
     city.baseline_parameters = baseline_parameters
     city.scenario_parameters[0] = scenario_parameters

--- a/SWEET_python/advanced_dst.py
+++ b/SWEET_python/advanced_dst.py
@@ -1,0 +1,514 @@
+"""
+Advanced DST (adst) — single-site methane modeling.
+
+This is the modeling backend for the ``/v1/site_emissions/adst`` endpoint. It is
+the "advanced" successor to ``City.sdst_v1_5``, but deliberately much simpler:
+the caller supplies waste mass and composition directly as time series, so this
+module does *no* waste generation, population growth, or TRACE reconciliation.
+It just turns the supplied numbers into a baseline and a scenario emissions
+time series.
+
+Design notes
+------------
+* Inputs arrive as :class:`SWEET_python.class_defs.Variant` objects carrying a
+  ``baseline`` and an optional ``scenario`` value. When ``scenario`` is omitted
+  it falls back to ``baseline``.
+* The scenario variant equals the baseline variant for every year before
+  ``implement_year`` and switches to the scenario inputs from ``implement_year``
+  onward — the same convention the rest of the SWEET model uses.
+* ``run_advanced_dst`` is a pure function: it returns the result and never
+  mutates shared state. It builds a throwaway :class:`City`/:class:`Landfill`
+  internally purely to reuse the tested emission engine and summation logic.
+* Eventually this module is meant to grow to handle whole-city, multi-site, and
+  diversion modeling together; for now it handles one site at a time.
+"""
+
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, Field
+
+import SWEET_python.defaults_2019 as defaults_2019
+from SWEET_python.city_params import City, CityParameters, CustomError
+from SWEET_python.class_defs import DecompositionRates, Fraction, LandfillType, Variant
+from SWEET_python.landfill import Landfill
+from SWEET_python.singapore_k import compute_singapore_k
+
+__all__ = ["AdvancedDSTRequest", "run_advanced_dst"]
+
+# The model is only ever evaluated over this window. Open years are validated
+# against MODEL_YEAR_MIN to avoid accidental giant simulations.
+MODEL_YEAR_MIN = 1950
+MODEL_YEAR_MAX = 2050
+
+# Order matters: waste_fractions vectors are sent in this column order.
+WASTE_COMPONENTS: List[str] = [
+    "food",
+    "green",
+    "wood",
+    "paper_cardboard",
+    "textiles",
+    "plastic",
+    "metal",
+    "glass",
+    "rubber",
+    "other",
+]
+# The SWEET engine only generates methane from the biodegradable components
+# (these are the components that have a k value and an L_0).
+DEGRADABLE_COMPONENTS: List[str] = [
+    "food",
+    "green",
+    "wood",
+    "paper_cardboard",
+    "textiles",
+]
+
+# Methane correction factor by landfill type (index == LandfillType value).
+# 0 landfill, 1 controlled dump, 2 open dump.
+MCF_BY_TYPE: List[float] = [1.0, 0.6, 0.4]
+SITE_TYPE_NAMES: List[str] = ["landfill", "controlled_dumpsite", "dumpsite"]
+
+# Oxidation factor lookup, mirroring City.sdst_v1_5 / Landfill.estimate_emissions.
+OX_NOCAP: Dict[str, float] = {"landfill": 0.1, "controlled_dumpsite": 0.05, "dumpsite": 0.0}
+OX_CAP: Dict[str, float] = {"landfill": 0.22, "controlled_dumpsite": 0.1, "dumpsite": 0.0}
+# A dump that is upgraded ("ameliorated") to an engineered landfill with gas
+# capture gets a higher oxidation factor than a landfill that always existed.
+OX_REMEDIATED_TO_LANDFILL = 0.18
+
+DEFAULT_FLARE_EFFICIENCY = 0.98
+
+
+# A yearly time series arrives over the wire as {year: value}. Pydantic coerces
+# JSON string keys ("2025") to ints.
+YearlyFloat = Dict[int, float]
+YearlyFractions = Dict[int, List[float]]
+
+
+class AdvancedDSTRequest(BaseModel):
+    """Request body for the advanced single-site DST endpoint.
+
+    Every per-scenario input is a :class:`Variant`. The frontend sends the raw
+    UI numbers (a total-mass series and a fractions series); all math, including
+    splitting the total into components, happens here in Python.
+    """
+
+    precipitation: float = Field(..., ge=0, description="Average annual precipitation, mm/year.")
+    implement_year: int = Field(..., description="Year scenario changes take effect.")
+    waste_mass: Variant[YearlyFloat] = Field(
+        ..., description="Total landfilled waste mass per year (tons), {year: tons}."
+    )
+    waste_fractions: Variant[YearlyFractions] = Field(
+        ...,
+        description=(
+            "Waste composition per year, {year: [10 fractions]} in the order "
+            "food, green, wood, paper_cardboard, textiles, plastic, metal, "
+            "glass, rubber, other."
+        ),
+    )
+    landfill_type: Variant[LandfillType] = Field(
+        ..., description="Site type: 0 landfill, 1 controlled dump, 2 open dump."
+    )
+    landfill_open_close: Variant[Tuple[int, int]] = Field(
+        ..., description="(open_year, close_year) of the site."
+    )
+    gas_capture_efficiency: Variant[YearlyFloat] = Field(
+        ..., description="Fraction of gas captured per year; 0 means no capture."
+    )
+    flaring: Optional[Variant[YearlyFloat]] = Field(
+        None, description="Flare destruction efficiency per year (defaults to 0.98)."
+    )
+    biocover: Optional[Variant[YearlyFloat]] = Field(
+        None, description="Biocover oxidation floor per year (a fraction; defaults to 0)."
+    )
+    temperature: float = Field(10.0, description="Average annual temperature, deg C.")
+    country: Optional[str] = Field(
+        None, description="ISO3 country code. Stored for identity; does not affect the math."
+    )
+    rmi_id: Optional[int] = Field(None, description="Site identifier. Stored for identity.")
+
+
+# --------------------------------------------------------------------------- #
+# Input -> time series helpers
+# --------------------------------------------------------------------------- #
+def _variant_get(variant: Optional[Variant], label: str):
+    """Return ``variant[label]`` with a graceful fallback to baseline."""
+    if variant is None:
+        return None
+    value = variant[label]
+    if value is None and label == "scenario":
+        return variant["baseline"]
+    return value
+
+
+def _yearly_to_series(
+    mapping: Optional[Dict[int, float]],
+    years: pd.Index,
+    default: Optional[float] = None,
+) -> pd.Series:
+    """Turn a ``{year: value}`` map into a series aligned to ``years``.
+
+    Missing interior years are forward/back filled. When ``mapping`` is empty a
+    ``default`` is required, otherwise we raise rather than silently model zeros.
+    """
+    if not mapping:
+        if default is None:
+            raise CustomError("invalid_parameters", "Missing required yearly time series.")
+        return pd.Series(float(default), index=years)
+    series = pd.Series({int(k): float(v) for k, v in mapping.items()})
+    series = series.sort_index().reindex(years).ffill().bfill()
+    if default is not None:
+        series = series.fillna(float(default))
+    return series
+
+
+def _fractions_to_df(mapping: Optional[Dict[int, List[float]]], years: pd.Index) -> pd.DataFrame:
+    """Turn a ``{year: [10 fractions]}`` map into a years x components frame."""
+    if not mapping:
+        raise CustomError("invalid_parameters", "Missing waste_fractions time series.")
+    rows: Dict[int, List[float]] = {}
+    for year, vector in mapping.items():
+        if len(vector) != len(WASTE_COMPONENTS):
+            raise CustomError(
+                "invalid_parameters",
+                f"waste_fractions for year {year} must have {len(WASTE_COMPONENTS)} values.",
+            )
+        rows[int(year)] = [float(x) for x in vector]
+    frame = pd.DataFrame.from_dict(rows, orient="index", columns=WASTE_COMPONENTS)
+    return frame.sort_index().reindex(years).ffill().bfill()
+
+
+def _variant_series(
+    variant: Optional[Variant],
+    years: pd.Index,
+    implement_year: int,
+    default: Optional[float],
+) -> Tuple[pd.Series, pd.Series]:
+    """Build (baseline_series, scenario_series) for a yearly Variant input.
+
+    The scenario series equals baseline before ``implement_year`` and switches to
+    the scenario inputs from ``implement_year`` onward.
+    """
+    baseline_map = _variant_get(variant, "baseline") if variant is not None else None
+    baseline = _yearly_to_series(baseline_map, years, default=default)
+
+    scenario_map = variant["scenario"] if variant is not None else None
+    if scenario_map is None:
+        return baseline, baseline.copy()
+
+    scenario_input = _yearly_to_series(scenario_map, years, default=default)
+    scenario = baseline.copy()
+    scenario.loc[implement_year:] = scenario_input.loc[implement_year:]
+    return baseline, scenario
+
+
+def _apply_window(mass_df: pd.DataFrame, open_year: int, close_year: int) -> pd.DataFrame:
+    """Zero out waste deposited before the site opens or after it closes."""
+    windowed = mass_df.copy()
+    windowed.loc[: int(open_year) - 1, :] = 0.0
+    windowed.loc[int(close_year):, :] = 0.0
+    return windowed
+
+
+# --------------------------------------------------------------------------- #
+# Model parameter construction
+# --------------------------------------------------------------------------- #
+def _representative_vector(fractions_df: pd.DataFrame, ref_year: int) -> SimpleNamespace:
+    """A single composition vector used for the k-value lookup.
+
+    The Wang et al. (2024) k method maps a composition to a single rate via a
+    coarse 8x8x8 lookup, and the existing ``advanced_dst`` path takes one vector
+    per scenario. We sample the composition at ``ref_year`` (the implement year),
+    matching the granularity of the rest of the scenario switch.
+    """
+    row = fractions_df.loc[ref_year]
+    return SimpleNamespace(**{component: float(row[component]) for component in WASTE_COMPONENTS})
+
+
+def _reindex_decomp(ks: DecompositionRates, years: pd.Index) -> DecompositionRates:
+    """compute_singapore_k returns 1990..2050 series; align them to model years."""
+
+    def fix(series: pd.Series) -> pd.Series:
+        return series.reindex(years).ffill().bfill()
+
+    return DecompositionRates(
+        food=fix(ks.food),
+        green=fix(ks.green),
+        wood=fix(ks.wood),
+        paper_cardboard=fix(ks.paper_cardboard),
+        textiles=fix(ks.textiles),
+    )
+
+
+def _decomposition_rates(
+    temperature: float,
+    precipitation: float,
+    implement_year: int,
+    years: pd.Index,
+    baseline_vector: SimpleNamespace,
+    scenario_vector: SimpleNamespace,
+) -> Tuple[DecompositionRates, DecompositionRates]:
+    """Per-variant decomposition rates (Wang et al. 2024).
+
+    The baseline landfill keeps baseline composition for all years, so its k is
+    constant. The scenario landfill uses baseline k before ``implement_year`` and
+    scenario k after, which ``compute_singapore_k(advanced_dst=True)`` produces.
+    """
+    baseline_only = {"baseline": baseline_vector, "scenario": baseline_vector}
+    scenario_mix = {"baseline": baseline_vector, "scenario": scenario_vector}
+
+    ks_baseline, _ = compute_singapore_k(
+        baseline_only, temperature, precipitation,
+        advanced_dst=True, implement_year=implement_year,
+    )
+    ks_scenario, _ = compute_singapore_k(
+        scenario_mix, temperature, precipitation,
+        advanced_dst=True, implement_year=implement_year,
+    )
+    return _reindex_decomp(ks_baseline, years), _reindex_decomp(ks_scenario, years)
+
+
+def _oxidation_series(
+    baseline_type: int,
+    scenario_type: int,
+    gas_capture: pd.Series,
+    biocover: pd.Series,
+    implement_year: int,
+    years: pd.Index,
+) -> pd.Series:
+    """Per-year oxidation factor.
+
+    Before ``implement_year`` the site is ``baseline_type``; after, it is
+    ``scenario_type``. For each year, gas capture (efficiency > 0) selects the
+    capped vs uncapped oxidation factor. A dump upgraded to an engineered
+    landfill with capture gets the higher remediated factor. The biocover series
+    acts as a floor.
+    """
+    baseline_name = SITE_TYPE_NAMES[baseline_type]
+    scenario_name = SITE_TYPE_NAMES[scenario_type]
+    ameliorated = scenario_type < baseline_type
+
+    values = []
+    for year in years:
+        has_capture = float(gas_capture.loc[year]) > 0
+        if year < implement_year:
+            value = OX_CAP[baseline_name] if has_capture else OX_NOCAP[baseline_name]
+        elif has_capture:
+            if ameliorated and scenario_type == LandfillType.landfill.value:
+                value = OX_REMEDIATED_TO_LANDFILL
+            else:
+                value = OX_CAP[scenario_name]
+        else:
+            value = OX_NOCAP[scenario_name]
+        values.append(max(value, float(biocover.loc[year])))
+    return pd.Series(values, index=years, dtype=float)
+
+
+def _city_instance_attrs(city: City, country: Optional[str]) -> Dict:
+    """The slice of City config the engine reads (notably ``components``)."""
+    return {
+        "city_name": city.city_name,
+        "country": country,
+        "components": city.components,
+        "div_components": city.div_components,
+        "waste_types": city.waste_types,
+        "unprocessable": city.unprocessable,
+        "non_compostable_not_targeted": city.non_compostable_not_targeted,
+        "combustion_reject_rate": city.combustion_reject_rate,
+        "recycling_reject_rates": city.recycling_reject_rates,
+    }
+
+
+def _make_parameters(
+    request: AdvancedDSTRequest,
+    fractions_df: pd.DataFrame,
+    ks: DecompositionRates,
+    city_instance_attrs: Dict,
+    implement_year: int,
+    scenario: int,
+) -> CityParameters:
+    """A minimal CityParameters carrying just what the engine needs.
+
+    Growth rates and year_of_data_pop are read by the engine but unused for a
+    directly-supplied mass series, so they are set to inert values.
+    """
+    return CityParameters(
+        precip=request.precipitation,
+        precip_zone=defaults_2019.get_precipitation_zone(request.precipitation),
+        temperature=request.temperature,
+        growth_rate_historic=1.0,
+        growth_rate_future=1.0,
+        year_of_data_pop={"baseline": implement_year, "scenario": implement_year},
+        mef_compost=0.0,
+        scenario=scenario,
+        implement_year=implement_year,
+        city_instance_attrs=city_instance_attrs,
+        ks=ks,
+        waste_fractions=fractions_df,
+        rmi_id=request.rmi_id,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def _validate(open_close_pairs: List[Tuple[int, int]], implement_year: int) -> int:
+    """Validate site dates and the implement year. Returns the model start year."""
+    open_years = []
+    for open_year, close_year in open_close_pairs:
+        open_year, close_year = int(open_year), int(close_year)
+        if not (MODEL_YEAR_MIN <= open_year <= MODEL_YEAR_MAX):
+            raise CustomError(
+                "invalid_year",
+                f"Landfill open year must be between {MODEL_YEAR_MIN} and {MODEL_YEAR_MAX} (got {open_year}).",
+            )
+        if not (MODEL_YEAR_MIN <= close_year <= MODEL_YEAR_MAX):
+            raise CustomError(
+                "invalid_year",
+                f"Landfill close year must be between {MODEL_YEAR_MIN} and {MODEL_YEAR_MAX} (got {close_year}).",
+            )
+        if close_year < open_year:
+            raise CustomError("invalid_year", "Landfill close year must be on or after open year.")
+        open_years.append(open_year)
+
+    model_start = min(open_years)
+    if not (model_start <= int(implement_year) <= MODEL_YEAR_MAX):
+        raise CustomError(
+            "invalid_year",
+            f"implement_year must be between {model_start} and {MODEL_YEAR_MAX} (got {implement_year}).",
+        )
+    return model_start
+
+
+# --------------------------------------------------------------------------- #
+# Public entry point
+# --------------------------------------------------------------------------- #
+def run_advanced_dst(request: AdvancedDSTRequest) -> Dict[str, pd.DataFrame]:
+    """Run the advanced single-site DST.
+
+    Returns ``{"baseline": total_emissions_df, "scenario": total_emissions_df}``
+    where each frame is indexed by year with a ``total`` column (tons CO2e).
+    """
+    implement_year = int(request.implement_year)
+
+    baseline_open, baseline_close = (int(x) for x in request.landfill_open_close["baseline"])
+    scenario_dates = request.landfill_open_close["scenario"] or request.landfill_open_close["baseline"]
+    scenario_open, scenario_close = (int(x) for x in scenario_dates)
+
+    model_start = _validate(
+        [(baseline_open, baseline_close), (scenario_open, scenario_close)],
+        implement_year,
+    )
+    years = pd.Index(range(model_start, MODEL_YEAR_MAX + 1), name="year")
+
+    # --- Waste mass by component (fractions x total), per variant ---
+    baseline_fractions = _fractions_to_df(request.waste_fractions["baseline"], years)
+    scenario_fractions = _fractions_to_df(
+        request.waste_fractions["scenario"] or request.waste_fractions["baseline"], years
+    )
+    baseline_total, scenario_total = _variant_series(request.waste_mass, years, implement_year, default=None)
+
+    baseline_mass = baseline_fractions.mul(baseline_total, axis=0)
+    scenario_mass = scenario_fractions.mul(scenario_total, axis=0)
+    # Scenario tracks baseline before changes take effect.
+    scenario_mass.loc[: implement_year - 1, :] = baseline_mass.loc[: implement_year - 1, :]
+    baseline_mass = _apply_window(baseline_mass, baseline_open, baseline_close)
+    scenario_mass = _apply_window(scenario_mass, scenario_open, scenario_close)
+
+    # --- Decomposition rates ---
+    ref_year = min(max(implement_year, int(years.min())), int(years.max()))
+    ks_baseline, ks_scenario = _decomposition_rates(
+        request.temperature,
+        request.precipitation,
+        implement_year,
+        years,
+        _representative_vector(baseline_fractions, ref_year),
+        _representative_vector(scenario_fractions, ref_year),
+    )
+
+    # --- MCF / gas capture / flaring / oxidation series ---
+    baseline_type = int(request.landfill_type["baseline"])
+    scenario_type = int(request.landfill_type["scenario"]) if request.landfill_type["scenario"] is not None else baseline_type
+
+    mcf_baseline = pd.Series(MCF_BY_TYPE[baseline_type], index=years, dtype=float)
+    mcf_scenario = mcf_baseline.copy()
+    mcf_scenario.loc[implement_year:] = MCF_BY_TYPE[scenario_type]
+
+    gas_baseline, gas_scenario = _variant_series(request.gas_capture_efficiency, years, implement_year, default=0.0)
+    flare_baseline, flare_scenario = _variant_series(request.flaring, years, implement_year, default=DEFAULT_FLARE_EFFICIENCY)
+    biocover_baseline, biocover_scenario = _variant_series(request.biocover, years, implement_year, default=0.0)
+
+    ox_baseline = _oxidation_series(baseline_type, baseline_type, gas_baseline, biocover_baseline, implement_year, years)
+    ox_scenario = _oxidation_series(baseline_type, scenario_type, gas_scenario, biocover_scenario, implement_year, years)
+
+    # --- Assemble city / landfills and run the engine ---
+    city = City("advanced_dst_site")
+    city_instance_attrs = _city_instance_attrs(city, request.country)
+
+    baseline_parameters = _make_parameters(request, baseline_fractions, ks_baseline, city_instance_attrs, implement_year, 0)
+    scenario_parameters = _make_parameters(request, scenario_fractions, ks_scenario, city_instance_attrs, implement_year, 1)
+
+    baseline_landfill = Landfill(
+        open_date=baseline_open,
+        close_date=baseline_close,
+        site_type=SITE_TYPE_NAMES[baseline_type],
+        mcf=mcf_baseline,
+        city_params_dict=baseline_parameters.update_cityparams_dict(),
+        city_instance_attrs=city_instance_attrs,
+        landfill_index=0,
+        gas_capture=bool((gas_baseline > 0).any()),
+        gas_capture_efficiency=gas_baseline,
+        flaring=flare_baseline,
+        oxidation_factor=ox_baseline,
+        ks=ks_baseline,
+        advanced=True,
+        implementation_year=implement_year,
+        scenario=0,
+    )
+    scenario_landfill = Landfill(
+        open_date=scenario_open,
+        close_date=scenario_close,
+        site_type=SITE_TYPE_NAMES[scenario_type],
+        mcf=mcf_scenario,
+        city_params_dict=scenario_parameters.update_cityparams_dict(),
+        city_instance_attrs=city_instance_attrs,
+        landfill_index=0,
+        gas_capture=bool((gas_scenario > 0).any()),
+        gas_capture_efficiency=gas_scenario,
+        flaring=flare_scenario,
+        oxidation_factor=ox_scenario,
+        ks=ks_scenario,
+        advanced=True,
+        implementation_year=implement_year,
+        scenario=1,
+    )
+
+    baseline_parameters.landfills = [baseline_landfill]
+    scenario_parameters.landfills = [scenario_landfill]
+    baseline_parameters.repopulate_attr_dicts()
+    scenario_parameters.repopulate_attr_dicts()
+
+    baseline_landfill.waste_mass_df = baseline_mass
+    baseline_landfill.oxidation_factor = ox_baseline
+    scenario_landfill.waste_mass_df = scenario_mass
+    scenario_landfill.oxidation_factor = ox_scenario
+
+    baseline_landfill.estimate_emissions(skip_ox=True)
+    scenario_landfill.estimate_emissions(skip_ox=True)
+
+    # No diversion in the advanced single-site DST: the supplied mass is the
+    # final landfilled mass, so there are no organic (compost/anaerobic) emissions.
+    baseline_parameters.organic_emissions = pd.DataFrame(0.0, index=years, columns=DEGRADABLE_COMPONENTS)
+    scenario_parameters.organic_emissions = pd.DataFrame(0.0, index=years, columns=DEGRADABLE_COMPONENTS)
+
+    city.baseline_parameters = baseline_parameters
+    city.scenario_parameters[0] = scenario_parameters
+    city.sum_landfill_emissions(scenario=0)
+    city.sum_landfill_emissions(scenario=1)
+
+    return {
+        "baseline": baseline_parameters.total_emissions,
+        "scenario": scenario_parameters.total_emissions,
+    }

--- a/SWEET_python/advanced_dst_city.py
+++ b/SWEET_python/advanced_dst_city.py
@@ -1,0 +1,448 @@
+"""
+Advanced DST (adst) — city-level, multi-landfill modeling.
+
+Backend for the ``/v1/site_emissions/adst_city_level`` endpoint. It is the
+city-level sibling of :mod:`SWEET_python.advanced_dst`: same "caller supplies
+time series directly" philosophy, but it models a whole city at once —
+diversion (compost / anaerobic / combustion / recycling) plus an arbitrary
+number of landfills that share the city's landfilled waste.
+
+Input shape
+-----------
+City-level quantities live at the top of the request; per-landfill quantities
+live in a list, one dict per landfill:
+
+* ``waste_mass`` here is total **generated** city waste per year (tons), BEFORE
+  diversion (unlike single-site adst where it is the landfilled mass).
+* ``diversion_fractions`` is, per pathway, a {year: fraction-of-generated} series.
+  The within-pathway component split is derived from the city composition
+  (so the frontend only sends overall pathway fractions, not per-component splits).
+* each landfill carries its own type / open-close / gas capture / flaring /
+  biocover. The split of the city's *landfilled* (net-of-diversion) waste across
+  landfills is a top-level time series, ``landfill_split_timeline``:
+  ``{year: [frac per landfill]}`` ordered to match the ``landfills`` list, with
+  each year's fractions summing to ~1.
+
+Diversion math, reject rates, the per-landfill split, and emissions aggregation
+mirror the tested ``City`` machinery (``_calculate_diverted_masses``,
+``LandfillWasteMassDF.create_advanced``, ``estimate_diversion_emissions``,
+``sum_landfill_emissions``); the leaf primitives are reused directly.
+"""
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, Field
+
+import SWEET_python.defaults_2019 as defaults_2019
+from SWEET_python.city_params import City, CityParameters, CustomError
+from SWEET_python.class_defs import DivsDF, LandfillType, LandfillWasteMassDF, Variant
+from SWEET_python import dst_common as common
+from SWEET_python.dst_common import YearlyFloat, YearlyFractions
+
+__all__ = ["AdvancedDSTCityRequest", "CityLandfillSpec", "run_advanced_dst_city"]
+
+DIVERSION_PATHWAYS = ["compost", "anaerobic", "combustion", "recycling"]
+SHARE_SUM_TOLERANCE = 0.02
+
+
+class CityLandfillSpec(BaseModel):
+    """One landfill within the city. All per-scenario fields are Variants."""
+
+    landfill_type: Variant[LandfillType] = Field(
+        ..., description="Site type: 0 landfill, 1 controlled dump, 2 open dump."
+    )
+    landfill_open_close: Variant[tuple[int, int]] = Field(
+        ..., description="(open_year, close_year) of this site."
+    )
+    gas_capture_efficiency: Variant[YearlyFloat] = Field(
+        ..., description="Fraction of gas captured per year; 0 means no capture."
+    )
+    flaring: Optional[Variant[YearlyFloat]] = Field(
+        None, description="Flare destruction efficiency per year (defaults to 0.98)."
+    )
+    biocover: Optional[Variant[YearlyFloat]] = Field(
+        None, description="Biocover oxidation floor per year (a fraction; defaults to 0)."
+    )
+
+
+class AdvancedDSTCityRequest(BaseModel):
+    """Request body for the city-level advanced DST endpoint."""
+
+    city_name: str = Field(..., description="City name (identity).")
+    precipitation: float = Field(..., ge=0, description="Average annual precipitation, mm/year.")
+    implement_year: int = Field(..., description="Year scenario changes take effect.")
+    waste_mass: Variant[YearlyFloat] = Field(
+        ..., description="Total GENERATED city waste per year (tons), before diversion. {year: tons}."
+    )
+    waste_fractions: Variant[YearlyFractions] = Field(
+        ...,
+        description=(
+            "City waste composition per year, {year: [10 fractions]} in the order "
+            "food, green, wood, paper_cardboard, textiles, plastic, metal, glass, "
+            "rubber, other."
+        ),
+    )
+    landfills: List[CityLandfillSpec] = Field(
+        ..., min_length=1, description="One entry per landfill in the city."
+    )
+    landfill_split_timeline: Variant[Dict[int, List[float]]] = Field(
+        ...,
+        description=(
+            "Fraction of the city's landfilled (net-of-diversion) waste sent to "
+            "each landfill per year: {year: [frac_landfill_0, frac_landfill_1, ...]}. "
+            "The list order matches the `landfills` list, and each year's fractions "
+            "should sum to ~1."
+        ),
+    )
+    diversion_fractions: Optional[Variant[Dict[str, YearlyFloat]]] = Field(
+        None,
+        description=(
+            "Per-pathway fraction of total generated waste diverted each year: "
+            "{compost|anaerobic|combustion|recycling: {year: fraction}}. Omitted "
+            "pathways are treated as zero."
+        ),
+    )
+    temperature: float = Field(10.0, description="Average annual temperature, deg C.")
+    country: Optional[str] = Field(None, description="ISO3 country code (identity).")
+    rmi_id: Optional[int] = Field(None, description="City/site identifier (identity).")
+
+
+# --------------------------------------------------------------------------- #
+# Diversion
+# --------------------------------------------------------------------------- #
+def _mef_compost(fractions_df: pd.DataFrame, ref_year: int) -> float:
+    """Per-city compost emission factor, from food/green share at the reference year.
+
+    Mirrors City.cityparams_obj_for_blank_site: weighted CH4 factor for the
+    food/green split, scaled to CO2e (the *1.1023*0.7 is baked in).
+    """
+    food = float(fractions_df.loc[ref_year, "food"])
+    green = float(fractions_df.loc[ref_year, "green"])
+    denom = food + green
+    if denom <= 0:
+        return 0.0
+    return (0.0055 * food / denom + 0.0139 * green / denom) * 1.1023 * 0.7
+
+
+def _diverted_masses(
+    fractions_df: pd.DataFrame,
+    total_generated: pd.Series,
+    div_fracs: Dict[str, Dict[int, float]],
+    city: City,
+    years: pd.Index,
+) -> DivsDF:
+    """Build a DivsDF of per-pathway, per-component diverted mass (tons/yr).
+
+    For each pathway: mass into the pathway = pathway_fraction * total_generated;
+    that mass is split across the pathway's eligible components using the city
+    composition (normalized within those components); then reject/yield rates are
+    applied. Matches City._calculate_diverted_masses, minus the legacy shims.
+    """
+    div_dfs: Dict[str, pd.DataFrame] = {}
+    for pathway in DIVERSION_PATHWAYS:
+        components = sorted(city.div_components[pathway])  # deterministic column order
+        sub = fractions_df[components]
+        denom = sub.sum(axis=1)
+        split = sub.div(denom, axis=0).replace([np.inf, -np.inf], 0.0).fillna(0.0)
+
+        pathway_fraction = common.yearly_to_series(div_fracs.get(pathway), years, default=0.0)
+        mass_into_pathway = pathway_fraction * total_generated
+        gross = split.mul(mass_into_pathway, axis=0)  # years x components
+
+        if pathway == "compost":
+            ncnt = city.non_compostable_not_targeted
+            ncnt_total = sum(split[c] * float(ncnt.get(c, 0.0)) for c in components)
+            net = gross.mul(1.0 - ncnt_total, axis=0)
+            keep = pd.Series({c: 1.0 - float(city.unprocessable.get(c, 0.0)) for c in components})
+            net = net.mul(keep, axis=1)
+        elif pathway == "anaerobic":
+            net = gross  # no loss
+        elif pathway == "combustion":
+            net = gross * (1.0 - float(city.combustion_reject_rate))
+        else:  # recycling — reject_rates are yield multipliers (fraction kept)
+            yields = pd.Series({c: float(city.recycling_reject_rates.get(c, 1.0)) for c in components})
+            net = gross.mul(yields, axis=1)
+
+        div_dfs[pathway] = net
+
+    return DivsDF(
+        compost=div_dfs["compost"],
+        anaerobic=div_dfs["anaerobic"],
+        combustion=div_dfs["combustion"],
+        recycling=div_dfs["recycling"],
+    )
+
+
+def _splice_divs(baseline: DivsDF, scenario: DivsDF, implement_year: int) -> DivsDF:
+    """Make the scenario diversion equal the baseline for years before implement_year."""
+    def splice(b: pd.DataFrame, s: pd.DataFrame) -> pd.DataFrame:
+        out = s.copy()
+        out.loc[: implement_year - 1, :] = b.loc[: implement_year - 1, :]
+        return out
+
+    return DivsDF(
+        compost=splice(baseline.compost, scenario.compost),
+        anaerobic=splice(baseline.anaerobic, scenario.anaerobic),
+        combustion=splice(baseline.combustion, scenario.combustion),
+        recycling=splice(baseline.recycling, scenario.recycling),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Parameters
+# --------------------------------------------------------------------------- #
+def _make_city_parameters(
+    request: AdvancedDSTCityRequest,
+    fractions_df: pd.DataFrame,
+    ks,
+    mef_compost: float,
+    divs_df: DivsDF,
+    city_instance_attrs: dict,
+    implement_year: int,
+    scenario: int,
+) -> CityParameters:
+    parameters = CityParameters(
+        precip=request.precipitation,
+        precip_zone=defaults_2019.get_precipitation_zone(request.precipitation),
+        temperature=request.temperature,
+        growth_rate_historic=1.0,
+        growth_rate_future=1.0,
+        year_of_data_pop={"baseline": implement_year, "scenario": implement_year},
+        mef_compost=mef_compost,
+        scenario=scenario,
+        implement_year=implement_year,
+        city_instance_attrs=city_instance_attrs,
+        ks=ks,
+        waste_fractions=fractions_df,
+        rmi_id=request.rmi_id,
+    )
+    # divs_df is typed as a plain DataFrame on CityParameters, but the engine
+    # (estimate_diversion_emissions) expects a DivsDF. Assign it post-construction
+    # so we bypass the field validator, matching how the existing City code does it.
+    parameters.divs_df = divs_df
+    return parameters
+
+
+def _split_timeline_to_df(
+    timeline: Dict[int, List[float]], years: pd.Index, n_landfills: int
+) -> pd.DataFrame:
+    """Parse a {year: [frac per landfill]} timeline into a years x landfill DataFrame.
+
+    Columns are 0..n_landfills-1 (matching the ``landfills`` list order); missing
+    years are forward/back filled.
+    """
+    if not timeline:
+        raise CustomError("invalid_parameters", "landfill_split_timeline is required.")
+    rows: Dict[int, List[float]] = {}
+    for year, fracs in timeline.items():
+        if len(fracs) != n_landfills:
+            raise CustomError(
+                "invalid_parameters",
+                f"landfill_split_timeline for year {year} must have {n_landfills} "
+                f"fractions (one per landfill, matching the landfills list).",
+            )
+        rows[int(year)] = [float(x) for x in fracs]
+    df = pd.DataFrame.from_dict(rows, orient="index", columns=list(range(n_landfills)))
+    return df.sort_index().reindex(years).ffill().bfill()
+
+
+def _validate_shares(shares: List[pd.Series], years: pd.Index, label: str) -> None:
+    """Each year's landfill shares should sum to ~1 (all net waste is landfilled somewhere)."""
+    total = sum(shares)
+    bad = total[(total < 1.0 - SHARE_SUM_TOLERANCE) | (total > 1.0 + SHARE_SUM_TOLERANCE)]
+    if not bad.empty:
+        first_year = int(bad.index[0])
+        raise CustomError(
+            "invalid_parameters",
+            f"{label} landfill waste_share fractions must sum to ~1 per year "
+            f"(year {first_year} sums to {float(bad.iloc[0]):.3f}).",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Public entry point
+# --------------------------------------------------------------------------- #
+def run_advanced_dst_city(request: AdvancedDSTCityRequest) -> dict[str, pd.DataFrame]:
+    """Run the city-level advanced DST.
+
+    Returns ``{"baseline": total_emissions_df, "scenario": total_emissions_df}``
+    (city totals summed across landfills + diversion), each indexed by year with a
+    ``total`` column.
+    """
+    implement_year = int(request.implement_year)
+
+    # --- Years: validate every landfill's open/close window ---
+    open_close_pairs = []
+    for spec in request.landfills:
+        b_open, b_close = (int(x) for x in spec.landfill_open_close["baseline"])
+        s_dates = spec.landfill_open_close["scenario"] or spec.landfill_open_close["baseline"]
+        s_open, s_close = (int(x) for x in s_dates)
+        open_close_pairs.append((b_open, b_close))
+        open_close_pairs.append((s_open, s_close))
+    model_start = common.validate_years(open_close_pairs, implement_year)
+    years = pd.Index(range(model_start, common.MODEL_YEAR_MAX + 1), name="year")
+
+    # --- City composition + total generated waste, per variant ---
+    baseline_fractions = common.fractions_to_df(request.waste_fractions["baseline"], years)
+    scenario_fractions = common.fractions_to_df(
+        request.waste_fractions["scenario"] or request.waste_fractions["baseline"], years
+    )
+    baseline_total, scenario_total = common.variant_series(request.waste_mass, years, implement_year, default=None)
+
+    wgen_baseline = baseline_fractions.mul(baseline_total, axis=0)
+    wgen_scenario = scenario_fractions.mul(scenario_total, axis=0)
+    wgen_scenario.loc[: implement_year - 1, :] = wgen_baseline.loc[: implement_year - 1, :]
+
+    # --- Diversion (per variant), with scenario tracking baseline pre-implement ---
+    city = City(request.city_name)
+    div_variant = request.diversion_fractions
+    baseline_div = (common.variant_get(div_variant, "baseline") or {}) if div_variant is not None else {}
+    scenario_div_raw = div_variant["scenario"] if div_variant is not None else None
+    scenario_div = scenario_div_raw if scenario_div_raw is not None else baseline_div
+
+    divs_baseline = _diverted_masses(baseline_fractions, baseline_total, baseline_div, city, years)
+    divs_scenario = _splice_divs(
+        divs_baseline,
+        _diverted_masses(scenario_fractions, scenario_total, scenario_div, city, years),
+        implement_year,
+    )
+
+    # Guard against diverting more than is generated (negative landfilled mass).
+    for label, wgen, divs in (("baseline", wgen_baseline, divs_baseline), ("scenario", wgen_scenario, divs_scenario)):
+        net = wgen.sub(divs.sum(), fill_value=0.0)
+        if (net < -1e-6).to_numpy().any():
+            raise CustomError(
+                "over_diversion",
+                f"{label}: diversion exceeds generated waste (negative landfilled mass).",
+            )
+
+    # --- City-wide decomposition rates + compost emission factors ---
+    ref_year = min(max(implement_year, int(years.min())), int(years.max()))
+    ks_baseline, ks_scenario = common.decomposition_rates(
+        request.temperature, request.precipitation, implement_year, years,
+        common.representative_vector(baseline_fractions, ref_year),
+        common.representative_vector(scenario_fractions, ref_year),
+    )
+    mef_baseline = _mef_compost(baseline_fractions, ref_year)
+    mef_scenario = _mef_compost(scenario_fractions, ref_year)
+
+    # --- Parameters ---
+    city_instance_attrs = common.city_instance_attrs(city, request.country)
+    baseline_parameters = _make_city_parameters(
+        request, baseline_fractions, ks_baseline, mef_baseline, divs_baseline, city_instance_attrs, implement_year, 0
+    )
+    scenario_parameters = _make_city_parameters(
+        request, scenario_fractions, ks_scenario, mef_scenario, divs_scenario, city_instance_attrs, implement_year, 1
+    )
+    baseline_params_dict = baseline_parameters.update_cityparams_dict()
+    scenario_params_dict = scenario_parameters.update_cityparams_dict()
+
+    # --- Per-landfill split of landfilled waste (top-level time series) ---
+    n_landfills = len(request.landfills)
+    baseline_timeline = common.variant_get(request.landfill_split_timeline, "baseline")
+    scenario_timeline = request.landfill_split_timeline["scenario"] or baseline_timeline
+    baseline_split = _split_timeline_to_df(baseline_timeline, years, n_landfills)
+    scenario_split = _split_timeline_to_df(scenario_timeline, years, n_landfills)
+    # Scenario tracks baseline before changes take effect.
+    scenario_split.loc[: implement_year - 1, :] = baseline_split.loc[: implement_year - 1, :]
+
+    # --- Build a landfill (baseline + scenario) per spec ---
+    baseline_landfills: List = []
+    scenario_landfills: List = []
+    baseline_masses: List[pd.DataFrame] = []
+    scenario_masses: List[pd.DataFrame] = []
+    baseline_ox: List[pd.Series] = []
+    scenario_ox: List[pd.Series] = []
+    baseline_shares: List[pd.Series] = []
+    scenario_shares: List[pd.Series] = []
+
+    for index, spec in enumerate(request.landfills):
+        base_type = int(spec.landfill_type["baseline"])
+        scen_type = int(spec.landfill_type["scenario"]) if spec.landfill_type["scenario"] is not None else base_type
+
+        b_open, b_close = (int(x) for x in spec.landfill_open_close["baseline"])
+        s_dates = spec.landfill_open_close["scenario"] or spec.landfill_open_close["baseline"]
+        s_open, s_close = (int(x) for x in s_dates)
+
+        gas_base, gas_scen = common.variant_series(spec.gas_capture_efficiency, years, implement_year, default=0.0)
+        flare_base, flare_scen = common.variant_series(spec.flaring, years, implement_year, default=common.DEFAULT_FLARE_EFFICIENCY)
+        bio_base, bio_scen = common.variant_series(spec.biocover, years, implement_year, default=0.0)
+        share_base = baseline_split[index]
+        share_scen = scenario_split[index]
+        baseline_shares.append(share_base)
+        scenario_shares.append(share_scen)
+
+        mcf_base = common.mcf_series(base_type, base_type, implement_year, years)
+        mcf_scen = common.mcf_series(base_type, scen_type, implement_year, years)
+        ox_base = common.oxidation_series(base_type, base_type, gas_base, bio_base, implement_year, years)
+        ox_scen = common.oxidation_series(base_type, scen_type, gas_scen, bio_scen, implement_year, years)
+        baseline_ox.append(ox_base)
+        scenario_ox.append(ox_scen)
+
+        # Net-of-diversion city waste, scaled to this landfill's per-year share.
+        mass_base = LandfillWasteMassDF.create_advanced(wgen_baseline, divs_baseline, share_base.copy()).df
+        mass_scen = LandfillWasteMassDF.create_advanced(wgen_scenario, divs_scenario, share_scen.copy()).df
+        mass_scen.loc[: implement_year - 1, :] = mass_base.loc[: implement_year - 1, :]
+        mass_base = common.apply_window(mass_base, b_open, b_close)
+        mass_scen = common.apply_window(mass_scen, s_open, s_close)
+        baseline_masses.append(mass_base)
+        scenario_masses.append(mass_scen)
+
+        baseline_landfills.append(common.build_landfill(
+            open_year=b_open, close_year=b_close, site_type_idx=base_type,
+            mcf=mcf_base, gas_capture_efficiency=gas_base, flaring=flare_base,
+            oxidation_factor=ox_base, ks=ks_baseline, city_params_dict=baseline_params_dict,
+            city_instance_attrs=city_instance_attrs, implement_year=implement_year,
+            scenario=0, landfill_index=index,
+        ))
+        scenario_landfills.append(common.build_landfill(
+            open_year=s_open, close_year=s_close, site_type_idx=scen_type,
+            mcf=mcf_scen, gas_capture_efficiency=gas_scen, flaring=flare_scen,
+            oxidation_factor=ox_scen, ks=ks_scenario, city_params_dict=scenario_params_dict,
+            city_instance_attrs=city_instance_attrs, implement_year=implement_year,
+            scenario=1, landfill_index=index,
+        ))
+
+    _validate_shares(baseline_shares, years, "baseline")
+    _validate_shares(scenario_shares, years, "scenario")
+
+    # --- Wire up and run the engine ---
+    baseline_parameters.landfills = baseline_landfills
+    scenario_parameters.landfills = scenario_landfills
+    baseline_parameters.repopulate_attr_dicts()
+    scenario_parameters.repopulate_attr_dicts()
+
+    for landfill, mass, ox in zip(baseline_landfills, baseline_masses, baseline_ox):
+        landfill.waste_mass_df = mass
+        landfill.oxidation_factor = ox
+        landfill.estimate_emissions(skip_ox=True)
+    for landfill, mass, ox in zip(scenario_landfills, scenario_masses, scenario_ox):
+        landfill.waste_mass_df = mass
+        landfill.oxidation_factor = ox
+        landfill.estimate_emissions(skip_ox=True)
+
+    city.baseline_parameters = baseline_parameters
+    city.scenario_parameters[0] = scenario_parameters
+
+    # Diversion (compost/anaerobic) emissions, then aggregate with landfills.
+    city.estimate_diversion_emissions(scenario=0)
+    city.estimate_diversion_emissions(scenario=1)
+
+    # mef_compost is a per-variant scalar applied to every year, so a scenario
+    # whose composition differs from baseline would emit different compost
+    # emissions even before implement_year (the diverted masses are spliced, but
+    # the scalar factor is not). Re-impose the baseline == scenario-before-
+    # implement_year convention on organic emissions, matching every other quantity.
+    scenario_parameters.organic_emissions.loc[: implement_year - 1, :] = (
+        baseline_parameters.organic_emissions.loc[: implement_year - 1, :]
+    )
+
+    city.sum_landfill_emissions(scenario=0)
+    city.sum_landfill_emissions(scenario=1)
+
+    return {
+        "baseline": baseline_parameters.total_emissions,
+        "scenario": scenario_parameters.total_emissions,
+    }

--- a/SWEET_python/dst_common.py
+++ b/SWEET_python/dst_common.py
@@ -1,0 +1,340 @@
+"""
+Shared helpers for the advanced DST endpoints (single-site `advanced_dst` and
+city-level `advanced_dst_city`).
+
+Everything here is input-shape-agnostic plumbing: turning {year: value} maps into
+year-aligned pandas objects, applying the baseline/scenario implement-year splice,
+deriving per-year MCF/oxidation, computing decomposition rates, and constructing a
+Landfill from already-built parameter series. The endpoint modules own their own
+request models and orchestration; this module owns the math primitives they share.
+"""
+
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+import SWEET_python.defaults_2019 as defaults_2019
+from SWEET_python.city_params import City, CustomError
+from SWEET_python.class_defs import DecompositionRates
+from SWEET_python.landfill import Landfill
+from SWEET_python.singapore_k import compute_singapore_k
+
+# The model is only ever evaluated over this window. Open years are validated
+# against MODEL_YEAR_MIN to avoid accidental giant simulations.
+MODEL_YEAR_MIN = 1950
+MODEL_YEAR_MAX = 2050
+
+# Order matters: waste_fractions vectors are sent in this column order.
+WASTE_COMPONENTS: List[str] = [
+    "food",
+    "green",
+    "wood",
+    "paper_cardboard",
+    "textiles",
+    "plastic",
+    "metal",
+    "glass",
+    "rubber",
+    "other",
+]
+# The SWEET engine only generates landfill methane from the biodegradable
+# components (these are the ones with a k value and an L_0).
+DEGRADABLE_COMPONENTS: List[str] = [
+    "food",
+    "green",
+    "wood",
+    "paper_cardboard",
+    "textiles",
+]
+
+# Methane correction factor by landfill type (index == LandfillType value):
+# 0 landfill, 1 controlled dump, 2 open dump.
+MCF_BY_TYPE: List[float] = [1.0, 0.6, 0.4]
+SITE_TYPE_NAMES: List[str] = ["landfill", "controlled_dumpsite", "dumpsite"]
+
+# Oxidation factor lookup, mirroring City.sdst_v1_5 / Landfill.estimate_emissions.
+OX_NOCAP: Dict[str, float] = {"landfill": 0.1, "controlled_dumpsite": 0.05, "dumpsite": 0.0}
+OX_CAP: Dict[str, float] = {"landfill": 0.22, "controlled_dumpsite": 0.1, "dumpsite": 0.0}
+# A dump upgraded ("ameliorated") to an engineered landfill with gas capture gets
+# a higher oxidation factor than a landfill that always existed.
+OX_REMEDIATED_TO_LANDFILL = 0.18
+
+DEFAULT_FLARE_EFFICIENCY = 0.98
+LANDFILL_LANDFILL_TYPE = 0  # LandfillType.landfill
+
+# A yearly time series arrives over the wire as {year: value}. Pydantic coerces
+# JSON string keys ("2025") to ints.
+YearlyFloat = Dict[int, float]
+YearlyFractions = Dict[int, List[float]]
+
+
+# --------------------------------------------------------------------------- #
+# Input -> time series
+# --------------------------------------------------------------------------- #
+def variant_get(variant, label: str):
+    """Return ``variant[label]`` with a graceful fallback to baseline."""
+    if variant is None:
+        return None
+    value = variant[label]
+    if value is None and label == "scenario":
+        return variant["baseline"]
+    return value
+
+
+def yearly_to_series(
+    mapping: Optional[Dict[int, float]],
+    years: pd.Index,
+    default: Optional[float] = None,
+) -> pd.Series:
+    """Turn a ``{year: value}`` map into a series aligned to ``years``.
+
+    Missing interior years are forward/back filled. When ``mapping`` is empty a
+    ``default`` is required, otherwise we raise rather than silently model zeros.
+    """
+    if not mapping:
+        if default is None:
+            raise CustomError("invalid_parameters", "Missing required yearly time series.")
+        return pd.Series(float(default), index=years)
+    series = pd.Series({int(k): float(v) for k, v in mapping.items()})
+    series = series.sort_index().reindex(years).ffill().bfill()
+    if default is not None:
+        series = series.fillna(float(default))
+    return series
+
+
+def fractions_to_df(mapping: Optional[Dict[int, List[float]]], years: pd.Index) -> pd.DataFrame:
+    """Turn a ``{year: [10 fractions]}`` map into a years x components frame."""
+    if not mapping:
+        raise CustomError("invalid_parameters", "Missing waste_fractions time series.")
+    rows: Dict[int, List[float]] = {}
+    for year, vector in mapping.items():
+        if len(vector) != len(WASTE_COMPONENTS):
+            raise CustomError(
+                "invalid_parameters",
+                f"waste_fractions for year {year} must have {len(WASTE_COMPONENTS)} values.",
+            )
+        rows[int(year)] = [float(x) for x in vector]
+    frame = pd.DataFrame.from_dict(rows, orient="index", columns=WASTE_COMPONENTS)
+    return frame.sort_index().reindex(years).ffill().bfill()
+
+
+def variant_series(
+    variant,
+    years: pd.Index,
+    implement_year: int,
+    default: Optional[float],
+) -> Tuple[pd.Series, pd.Series]:
+    """Build (baseline_series, scenario_series) for a yearly Variant input.
+
+    The scenario series equals baseline before ``implement_year`` and switches to
+    the scenario inputs from ``implement_year`` onward.
+    """
+    baseline_map = variant_get(variant, "baseline") if variant is not None else None
+    baseline = yearly_to_series(baseline_map, years, default=default)
+
+    scenario_map = variant["scenario"] if variant is not None else None
+    if scenario_map is None:
+        return baseline, baseline.copy()
+
+    scenario_input = yearly_to_series(scenario_map, years, default=default)
+    scenario = baseline.copy()
+    scenario.loc[implement_year:] = scenario_input.loc[implement_year:]
+    return baseline, scenario
+
+
+def apply_window(mass_df: pd.DataFrame, open_year: int, close_year: int) -> pd.DataFrame:
+    """Zero out waste deposited before the site opens or after it closes."""
+    windowed = mass_df.copy()
+    windowed.loc[: int(open_year) - 1, :] = 0.0
+    windowed.loc[int(close_year):, :] = 0.0
+    return windowed
+
+
+# --------------------------------------------------------------------------- #
+# Decomposition rates (Wang et al. 2024)
+# --------------------------------------------------------------------------- #
+def representative_vector(fractions_df: pd.DataFrame, ref_year: int) -> SimpleNamespace:
+    """A single composition vector used for the k-value lookup.
+
+    The Wang et al. (2024) k method maps a composition to a single rate via a
+    coarse 8x8x8 lookup, and the existing ``advanced_dst`` path takes one vector
+    per scenario. We sample the composition at ``ref_year`` (the implement year),
+    matching the granularity of the rest of the scenario switch.
+    """
+    row = fractions_df.loc[ref_year]
+    return SimpleNamespace(**{component: float(row[component]) for component in WASTE_COMPONENTS})
+
+
+def _reindex_decomp(ks: DecompositionRates, years: pd.Index) -> DecompositionRates:
+    """compute_singapore_k returns 1990..2050 series; align them to model years."""
+
+    def fix(series: pd.Series) -> pd.Series:
+        return series.reindex(years).ffill().bfill()
+
+    return DecompositionRates(
+        food=fix(ks.food),
+        green=fix(ks.green),
+        wood=fix(ks.wood),
+        paper_cardboard=fix(ks.paper_cardboard),
+        textiles=fix(ks.textiles),
+    )
+
+
+def decomposition_rates(
+    temperature: float,
+    precipitation: float,
+    implement_year: int,
+    years: pd.Index,
+    baseline_vector: SimpleNamespace,
+    scenario_vector: SimpleNamespace,
+) -> Tuple[DecompositionRates, DecompositionRates]:
+    """Per-variant decomposition rates.
+
+    The baseline keeps baseline composition for all years, so its k is constant.
+    The scenario uses baseline k before ``implement_year`` and scenario k after,
+    which ``compute_singapore_k(advanced_dst=True)`` produces.
+    """
+    baseline_only = {"baseline": baseline_vector, "scenario": baseline_vector}
+    scenario_mix = {"baseline": baseline_vector, "scenario": scenario_vector}
+
+    ks_baseline, _ = compute_singapore_k(
+        baseline_only, temperature, precipitation,
+        advanced_dst=True, implement_year=implement_year,
+    )
+    ks_scenario, _ = compute_singapore_k(
+        scenario_mix, temperature, precipitation,
+        advanced_dst=True, implement_year=implement_year,
+    )
+    return _reindex_decomp(ks_baseline, years), _reindex_decomp(ks_scenario, years)
+
+
+# --------------------------------------------------------------------------- #
+# Per-landfill parameter series and construction
+# --------------------------------------------------------------------------- #
+def oxidation_series(
+    baseline_type: int,
+    scenario_type: int,
+    gas_capture: pd.Series,
+    biocover: pd.Series,
+    implement_year: int,
+    years: pd.Index,
+) -> pd.Series:
+    """Per-year oxidation factor for one landfill.
+
+    Before ``implement_year`` the site is ``baseline_type``; after, it is
+    ``scenario_type``. For each year, gas capture (efficiency > 0) selects the
+    capped vs uncapped oxidation factor. A dump upgraded to an engineered landfill
+    with capture gets the higher remediated factor. ``biocover`` acts as a floor.
+    """
+    baseline_name = SITE_TYPE_NAMES[baseline_type]
+    scenario_name = SITE_TYPE_NAMES[scenario_type]
+    ameliorated = scenario_type < baseline_type
+
+    values = []
+    for year in years:
+        has_capture = float(gas_capture.loc[year]) > 0
+        if year < implement_year:
+            value = OX_CAP[baseline_name] if has_capture else OX_NOCAP[baseline_name]
+        elif has_capture:
+            if ameliorated and scenario_type == LANDFILL_LANDFILL_TYPE:
+                value = OX_REMEDIATED_TO_LANDFILL
+            else:
+                value = OX_CAP[scenario_name]
+        else:
+            value = OX_NOCAP[scenario_name]
+        values.append(max(value, float(biocover.loc[year])))
+    return pd.Series(values, index=years, dtype=float)
+
+
+def mcf_series(baseline_type: int, scenario_type: int, implement_year: int, years: pd.Index) -> pd.Series:
+    """MCF series for one landfill: baseline type before implement_year, scenario after."""
+    series = pd.Series(MCF_BY_TYPE[baseline_type], index=years, dtype=float)
+    series.loc[implement_year:] = MCF_BY_TYPE[scenario_type]
+    return series
+
+
+def build_landfill(
+    *,
+    open_year: int,
+    close_year: int,
+    site_type_idx: int,
+    mcf: pd.Series,
+    gas_capture_efficiency: pd.Series,
+    flaring: pd.Series,
+    oxidation_factor: pd.Series,
+    ks: DecompositionRates,
+    city_params_dict: dict,
+    city_instance_attrs: dict,
+    implement_year: int,
+    scenario: int,
+    landfill_index: int = 0,
+) -> Landfill:
+    """Construct one advanced Landfill from already-built per-year series.
+
+    The caller assigns ``waste_mass_df`` afterward (advanced landfills don't derive
+    it in __init__) and then calls ``estimate_emissions(skip_ox=True)``.
+    """
+    return Landfill(
+        open_date=open_year,
+        close_date=close_year,
+        site_type=SITE_TYPE_NAMES[site_type_idx],
+        mcf=mcf,
+        city_params_dict=city_params_dict,
+        city_instance_attrs=city_instance_attrs,
+        landfill_index=landfill_index,
+        gas_capture=bool((gas_capture_efficiency > 0).any()),
+        gas_capture_efficiency=gas_capture_efficiency,
+        flaring=flaring,
+        oxidation_factor=oxidation_factor,
+        ks=ks,
+        advanced=True,
+        implementation_year=implement_year,
+        scenario=scenario,
+    )
+
+
+def city_instance_attrs(city: City, country: Optional[str]) -> Dict:
+    """The slice of City config the engine reads (notably ``components``)."""
+    return {
+        "city_name": city.city_name,
+        "country": country,
+        "components": city.components,
+        "div_components": city.div_components,
+        "waste_types": city.waste_types,
+        "unprocessable": city.unprocessable,
+        "non_compostable_not_targeted": city.non_compostable_not_targeted,
+        "combustion_reject_rate": city.combustion_reject_rate,
+        "recycling_reject_rates": city.recycling_reject_rates,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def validate_years(open_close_pairs: List[Tuple[int, int]], implement_year: int) -> int:
+    """Validate site dates and the implement year. Returns the model start year."""
+    open_years = []
+    for open_year, close_year in open_close_pairs:
+        open_year, close_year = int(open_year), int(close_year)
+        if not (MODEL_YEAR_MIN <= open_year <= MODEL_YEAR_MAX):
+            raise CustomError(
+                "invalid_year",
+                f"Landfill open year must be between {MODEL_YEAR_MIN} and {MODEL_YEAR_MAX} (got {open_year}).",
+            )
+        if not (MODEL_YEAR_MIN <= close_year <= MODEL_YEAR_MAX):
+            raise CustomError(
+                "invalid_year",
+                f"Landfill close year must be between {MODEL_YEAR_MIN} and {MODEL_YEAR_MAX} (got {close_year}).",
+            )
+        if close_year < open_year:
+            raise CustomError("invalid_year", "Landfill close year must be on or after open year.")
+        open_years.append(open_year)
+
+    model_start = min(open_years)
+    if not (model_start <= int(implement_year) <= MODEL_YEAR_MAX):
+        raise CustomError(
+            "invalid_year",
+            f"implement_year must be between {model_start} and {MODEL_YEAR_MAX} (got {implement_year}).",
+        )
+    return model_start


### PR DESCRIPTION
Jira: WP-186 — modeling backend for the WasteMAP ADST endpoints (companion PR RMI/WasteMAP#704).

## What

The modeling backend for the Advanced DST (ADST) prototype, the cleaned-up successor to `City.sdst_v1_5`:

- `advanced_dst.py` — `run_advanced_dst`: **single landfill**.
- `advanced_dst_city.py` — `run_advanced_dst_city`: **whole city** — multiple landfills + diversion (compost / anaerobic / combustion / recycling).
- `dst_common.py` — shared helpers (year validation, time-series builders, k / MCF / oxidation series, landfill construction).

## Why

`sdst_v1_5` had grown unwieldy. ADST is a simpler, time-series-in / time-series-out design: the caller supplies waste mass, composition, landfill params (and, for cities, diversion) as baseline/scenario time series, and gets baseline + scenario emissions back.

## How it works (brief)

- One `City` holds two `CityParameters` (baseline and scenario), each carrying the list of landfills; aggregation reuses `sum_landfill_emissions`.
- The scenario equals the baseline before `implement_year` and switches to the intervention after — spliced consistently across every quantity, including the top-level `landfill_split_timeline` (`{year: [frac per landfill]}`).
- Reuses the tested engine (`Landfill`, `SWEET`, `compute_singapore_k`, `LandfillWasteMassDF.create_advanced`, `estimate_diversion_emissions`, `sum_landfill_emissions`).

## Reviewer notes

- Additive: `advanced_dst_city.py` and `dst_common.py` are new; `advanced_dst.py` was refactored onto `dst_common` (behavior unchanged). The existing `City` methods and `sdst_v1_5` are untouched.
- An adversarial review caught a compost emission-factor splice bug (scenario diverged from baseline pre-`implement_year` when compositions differed) — fixed and covered by a regression test.
- Branched off `main`, independent of `k-min-fix`.
- Also gitignores the local `CLAUDE.md`.

## Definition of Done

- [x] Tests pass — exercised by the WasteMAP companion PR's fast tests (8 single-site + 12 city-level)
- [ ] Reviewed & merged
- Docs: n/a
