### PR TITLE
Keep decomposition rate (k) physical for cold/dry sites; centralize waste-composition defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ SWEET_python.egg-info/
 build/
 SWEET_python/unused
 SWEET_python.egg-info
+# Local PR-body drafts (edit in VS Code, sync to GitHub via `gh pr edit`)
+/pr-drafts/

--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -937,12 +937,7 @@ class City:
             self.waste_fractions_defaults = False
             if waste_fractions.isna().all():
                 self.waste_fractions_defaults = True
-                if iso3 in defaults_2019.waste_fractions_country:
-                    waste_fractions = defaults_2019.waste_fractions_country.loc[iso3, :]
-                else:
-                    # if region == "Rest of Oceania":
-                    #     print(self.city_name)
-                    waste_fractions = defaults_2019.waste_fraction_defaults.loc[region, :]
+                waste_fractions = defaults_2019.waste_composition_for(iso3, region)
             else:
                 waste_fractions.fillna(0, inplace=True)
                 # waste_fractions['textiles'] = 0
@@ -950,12 +945,7 @@ class City:
             if (waste_fractions.sum() < 0.98) or (waste_fractions.sum() > 1.02):
                 self.waste_fractions_defaults = True
                 # print('waste fractions do not sum to 1')
-                if iso3 in defaults_2019.waste_fractions_country:
-                    waste_fractions = defaults_2019.waste_fractions_country.loc[iso3, :]
-                else:
-                    # if region == "Rest of Oceania":
-                    #     print(self.city_name)
-                    waste_fractions = defaults_2019.waste_fraction_defaults.loc[region, :]
+                waste_fractions = defaults_2019.waste_composition_for(iso3, region)
 
             waste_fractions_dict = waste_fractions.to_dict()
 
@@ -3026,16 +3016,7 @@ class City:
         waste_fractions_defaults = False
         if waste_fractions.isna().all():
             waste_fractions_defaults = True
-            if self.iso3 in defaults_2019.waste_fractions_country:
-                waste_fractions = defaults_2019.waste_fractions_country.loc[
-                    self.iso3, :
-                ]
-            else:
-                # if self.region == "Rest of Oceania":
-                #     print('oceania, dunno', self.city_name)
-                waste_fractions = defaults_2019.waste_fraction_defaults.loc[
-                    self.region, :
-                ]
+            waste_fractions = defaults_2019.waste_composition_for(self.iso3, self.region)
         else:
             waste_fractions.fillna(0, inplace=True)
             # waste_fractions['textiles'] = 0
@@ -3043,16 +3024,7 @@ class City:
         if (waste_fractions.sum() < 0.98) or (waste_fractions.sum() > 1.02):
             waste_fractions_defaults = True
             # print('waste fractions do not sum to 1')
-            if self.iso3 in defaults_2019.waste_fractions_country:
-                waste_fractions = defaults_2019.waste_fractions_country.loc[
-                    self.iso3, :
-                ]
-            else:
-                # if self.region == "Rest of Oceania":
-                #     print('oceania, dunno', self.name)
-                waste_fractions = defaults_2019.waste_fraction_defaults.loc[
-                    self.region, :
-                ]
+            waste_fractions = defaults_2019.waste_composition_for(self.iso3, self.region)
 
         waste_fractions = waste_fractions.to_dict()
 
@@ -3459,16 +3431,7 @@ class City:
 
             # Waste fractions
             waste_fractions_defaults = True
-            if self.iso3 in defaults_2019.waste_fractions_country:
-                waste_fractions = defaults_2019.waste_fractions_country.loc[
-                    self.iso3, :
-                ]
-            else:
-                # if self.region == "Rest of Oceania":
-                #     print('oceania, dunno', self.city_name)
-                waste_fractions = defaults_2019.waste_fraction_defaults.loc[
-                    self.region, :
-                ]
+            waste_fractions = defaults_2019.waste_composition_for(self.iso3, self.region)
 
             # Normalize waste fractions to sum to 1
             wf_norm = waste_fractions / waste_fractions.sum()
@@ -3738,16 +3701,7 @@ class City:
 
             # Waste fractions
             waste_fractions_defaults = True
-            if self.iso3 in defaults_2019.waste_fractions_country:
-                waste_fractions = defaults_2019.waste_fractions_country.loc[
-                    self.iso3, :
-                ]
-            else:
-                # if self.region == "Rest of Oceania":
-                #     print('oceania, dunno', self.city_name)
-                waste_fractions = defaults_2019.waste_fraction_defaults.loc[
-                    self.region, :
-                ]
+            waste_fractions = defaults_2019.waste_composition_for(self.iso3, self.region)
 
             # Normalize waste fractions to sum to 1
             wf_norm = waste_fractions / waste_fractions.sum()
@@ -4443,12 +4397,7 @@ class City:
         waste_mass = waste_per_capita * population / 1000 * 365  # in tons/year
 
         # Retrieve and normalize waste fractions
-        if iso3 in defaults_2019.waste_fractions_country:
-            waste_fractions_series = defaults_2019.waste_fractions_country.loc[iso3, :]
-        else:
-            waste_fractions_series = defaults_2019.waste_fraction_defaults.loc[
-                region, :
-            ]
+        waste_fractions_series = defaults_2019.waste_composition_for(iso3, region)
 
         waste_fractions_normalized = (
             waste_fractions_series / waste_fractions_series.sum()
@@ -9123,10 +9072,7 @@ class City:
             # )
 
         # Waste fractions
-        if iso3 in defaults_2019.waste_fractions_country:
-            waste_fractions = defaults_2019.waste_fractions_country.loc[iso3, :]
-        else:
-            waste_fractions = defaults_2019.waste_fraction_defaults.loc[region, :]
+        waste_fractions = defaults_2019.waste_composition_for(iso3, region)
 
         # Normalize the waste fractions so that they sum to 1.
         waste_fractions = waste_fractions / waste_fractions.sum()

--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -130,6 +130,12 @@ class CityParameters(BaseModel):
             None
         """
         self.temp = self.temperature
+        if self.temperature is None or pd.isna(self.temperature):
+            asset = (self.city_instance_attrs or {}).get("city_name", self.rmi_id)
+            print(
+                f"WARNING: _singapore_k: missing temperature for asset {asset}; "
+                f"decomposition rate k will be NaN (this shouldn't happen)"
+            )
         self.ks, self.bf = compute_singapore_k(
             self.waste_fractions,
             self.temperature,

--- a/SWEET_python/defaults_2019.py
+++ b/SWEET_python/defaults_2019.py
@@ -383,13 +383,41 @@ waste_fractions_country.columns = [
     "textiles",
     "nappies",
     "rubber",
-    "plastics",
+    "plastic",  # singular to match waste_fraction_defaults and the model components
     "metal",
     "glass",
     "other",
 ]
 waste_fractions_country["other"] += waste_fractions_country["nappies"]
 waste_fractions_country = waste_fractions_country.drop("nappies", axis=1)
+
+
+def waste_composition_for(iso3, region):
+    """Default waste-fraction Series (normalized to sum 1) for a site.
+
+    Prefer the country-specific table, but fall back to the regional default
+    when the country is absent OR its plastic fraction is missing/zero. Several
+    country rows carry no plastic data; a zero plastic share is the tell-tale
+    of an incomplete row that would otherwise model an implausible no-plastic
+    waste stream (metal/glass are small and not worth rejecting a row over).
+
+    The country table is on a 0-100 (percent) scale and the regional table on a
+    0-1 (fraction) scale, so we normalize before returning to make the two
+    interchangeable for callers (some of which feed the result straight into the
+    model without their own normalization step).
+    """
+    row = None
+    if iso3 in waste_fractions_country.index:
+        candidate = waste_fractions_country.loc[iso3, :]
+        plastic = candidate.get("plastic")
+        if pd.notna(plastic) and plastic > 0:
+            row = candidate
+    if row is None:
+        row = waste_fraction_defaults.loc[region, :]
+    total = row.sum()
+    return row / total if total else row
+
+
 region_lookup = {
     "China": "Eastern Asia",
     "Japan": "Eastern Asia",

--- a/SWEET_python/singapore_k/singapore_k.py
+++ b/SWEET_python/singapore_k/singapore_k.py
@@ -322,9 +322,11 @@ def _compute_temperature_factor(temperature):
     # boundary instead of extrapolating; with t = temperature + 10 this is
     # equivalent to clamping ambient temperature to [-10 C, 45 C]. tf is 0 at
     # both boundaries, and the k floor (K_MIN_PER_YEAR) downstream then keeps
-    # cold sites physical.
+    # cold sites physical. np.clip (unlike max/min) preserves NaN, so a missing
+    # temperature stays NaN -> NaN k rather than being silently floored; the
+    # caller (_singapore_k) logs which asset is missing a temperature.
     t = temperature + 10  # landfill is warmer than ambient
-    t = max(tmin, min(tmax, t))
+    t = np.clip(t, tmin, tmax)
 
     num = (t - tmax) * (t - tmin) ** 2
     denom = (topt - tmin) * (

--- a/SWEET_python/singapore_k/singapore_k.py
+++ b/SWEET_python/singapore_k/singapore_k.py
@@ -12,6 +12,17 @@ import pandas as pd
 from SWEET_python.class_defs import DecompositionRates
 
 
+# Minimum decomposition rate (1/yr). IPCC (2019 refinement) Vol. 5 Table 3.3
+# gives a bulk-MSW default of 0.05/yr for dry boreal/temperate conditions, with
+# a range whose low end is 0.04/yr. We floor k here because the Wang et al.
+# (2024) temperature factor drives k toward 0 for cold/dry sites (tf -> 0 at
+# ambient -10 C), which produces physically implausible near-zero methane
+# generation and an emissions factor that is hypersensitive to tiny temperature
+# differences. 0.04 is the lowest defensible bulk default, so no real site
+# should decay slower than this.
+K_MIN_PER_YEAR = 0.04
+
+
 def _build_lookup_array():
     """Build the 3D composition lookup array (bs, bf, nb) for kc values."""
     lookup_array = np.zeros((8, 8, 8))
@@ -303,7 +314,17 @@ def _compute_temperature_factor(temperature):
     tmin = 0
     tmax = 55
     topt = 35
+    # The Ratkowsky response is only fitted for landfill temperatures in
+    # [tmin, tmax]. Outside that range it extrapolates nonsensically: below
+    # tmin the squared (t - tmin) term makes tf spuriously positive AND
+    # *increasing* as the site gets colder (colder modeled as faster decay).
+    # Clamp the input to the valid domain so we evaluate at the nearest
+    # boundary instead of extrapolating; with t = temperature + 10 this is
+    # equivalent to clamping ambient temperature to [-10 C, 45 C]. tf is 0 at
+    # both boundaries, and the k floor (K_MIN_PER_YEAR) downstream then keeps
+    # cold sites physical.
     t = temperature + 10  # landfill is warmer than ambient
+    t = max(tmin, min(tmax, t))
 
     num = (t - tmax) * (t - tmin) ** 2
     denom = (topt - tmin) * (
@@ -352,6 +373,11 @@ def _create_series(kc, tf, fm, implement_year=None, advanced_baseline=False,
     else:
         baseline_series = kc * tf * fm
         years.loc[:] = baseline_series
+
+    # Floor the decomposition rate at the IPCC dry-boreal low-end default.
+    # Cold/dry sites can otherwise drive k toward 0 (tf -> 0 near ambient
+    # -10 C); clip leaves any genuine NaN entries untouched. See K_MIN_PER_YEAR.
+    years = years.clip(lower=K_MIN_PER_YEAR)
 
     return years
 


### PR DESCRIPTION
**Type:** Bug fix + refactor &nbsp;·&nbsp; **Labels:** `bug`, `enhancement` &nbsp;·&nbsp; Pairs with `RMI_Climate_TRACE_Waste_Methane` PR #60

## Summary
Two model-side fixes (the SWEET half of the `RMI_Climate_TRACE_Waste_Methane` `k-min-fix` work):
1. Stop cold/dry sites from getting a physically implausible decomposition rate (k).
2. Centralize the country-vs-region waste-composition default into one helper, with a fallback for missing/zero plastic.

## 1. Cold-site decomposition rate (k) — bug fix (`singapore_k/singapore_k.py`)
**Problem.** The temperature response is only fitted for landfill temperatures in `[tmin = 0, tmax = 55]` (≈ ambient −10 °C to 45 °C). Below `tmin` it extrapolates nonsensically. That drives `k → 0` for cold/dry sites, giving near-zero methane generation and an emissions factor hypersensitive to tiny temperature differences.

**Fix.**
- Clamp the temperature input to the fitted domain `[tmin, tmax]`, so we evaluate at the nearest boundary instead of extrapolating (`tf = 0` at both ends).
- Floor the final decomposition rate at `K_MIN_PER_YEAR = 0.04 /yr` — the IPCC 2019 Refinement (Vol. 5, Table 3.3) low end of the dry boreal/temperate bulk-MSW range. No real site should decay slower than this. (`clip` leaves genuine NaNs untouched.)

## 2. Centralized waste-composition defaults — refactor + fix (`defaults_2019.py`, `city_params.py`)
- New `defaults_2019.waste_composition_for(iso3, region)`: returns the country-specific default composition, falling back to the regional default when the country is absent **or its plastic share is missing/zero** (several country rows carry no plastic data, and a zero-plastic stream is implausible). Normalizes to sum 1 (the country table is 0–100, the regional table 0–1).
- Replaces ~7 duplicated inline `if iso3 in waste_fractions_country: … else: waste_fraction_defaults.loc[region]` blocks in `city_params.py` with calls to the helper (the large deletion in the diff).
- Renames the country-table column `plastics` → `plastic` to match `waste_fraction_defaults` and the model components.

## Why this exists
`RMI_Climate_TRACE_Waste_Methane` (branch `k-min-fix`) imports `waste_composition_for` and depends on the k floor — this is the model-side half, so the two land together. (The pipeline previously failed with `ImportError: cannot import name 'waste_composition_for'` until this was committed and deployed.)

## Reviewer notes
- **Output impact (not a breaking change):** estimates shift for (a) cold/dry sites (higher, more physical k → more methane) and (b) sites whose country composition lacked plastic (now the regional fallback). Function signatures and data schemas are unchanged, so consumers (the TRACE pipeline) call exactly as before.
- **Merge alongside `RMI_Climate_TRACE_Waste_Methane` PR #60** — the pipeline branch imports `waste_composition_for` from here.
