### PR TITLE
Modeled landfills use measured site oxidation when available

### DIFF
--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -63,6 +63,14 @@ def _build_oxidation_series(default_value, canonical_row, time_series_rows, year
     else:
         frame = None
 
+    # This default fallback is intentional and load-bearing for callers whose input
+    # frame carries no per-year `oxidation` column -- e.g. the older city DST /
+    # make_cities_table path, which predates per-year oxidation and supplies a single
+    # baseline value elsewhere. The Climate TRACE sites AND cities pipelines both SELECT
+    # `oxidation` into their multi-row frames (landfill_table_ops), so measured oxidation
+    # IS used there; this only defaults when the column is genuinely absent. (Edge case,
+    # not produced by any current caller: oxidation present only on canonical_row while a
+    # DataFrame time_series_rows lacks it would be skipped here.)
     if frame is None or 'oxidation' not in frame.columns:
         return series
 

--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -30,6 +30,64 @@ from datetime import datetime
 import time
 
 
+def _build_oxidation_series(default_value, canonical_row, time_series_rows, years_range):
+    """Per-year oxidation factor for one modeled landfill, preferring per-site input
+    oxidation over the type/gas-capture default.
+
+    A site can have several input rows from independent sources. Oxidation carries no
+    year of its own in the source data -- the value that varies row-to-row is the
+    *emissions* year (``reported_emissions_year``), not an oxidation year -- so we use
+    the site-wide mean of the available input oxidation values as a constant baseline
+    across all model years, then overwrite individual years with that year's value
+    (mean of any conflicting same-year rows) where an emissions year is present.
+
+    When the site has no usable input oxidation, fall back to ``default_value`` (the
+    type/gas-capture default) broadcast across all years -- i.e. the prior behaviour.
+    Input values are used as-is (no clamping); e.g. a measured 0.35 passes through.
+
+    ``time_series_rows`` is a DataFrame for multi-row sites and a Series for single-row
+    sites; ``canonical_row`` is the single deduped row. Either may carry ``oxidation``.
+    """
+    years_index = pd.Index(years_range)
+    series = pd.Series(float(default_value), index=years_index)
+
+    # Assemble the site's input rows as a frame so single-row (Series) and multi-row
+    # (DataFrame) sites are handled uniformly. Prefer the multi-row frame -- it holds
+    # every source record -- and fall back to the single canonical row.
+    if isinstance(time_series_rows, pd.DataFrame):
+        frame = time_series_rows
+    elif isinstance(canonical_row, pd.DataFrame):
+        frame = canonical_row
+    elif isinstance(canonical_row, pd.Series):
+        frame = canonical_row.to_frame().T
+    else:
+        frame = None
+
+    if frame is None or 'oxidation' not in frame.columns:
+        return series
+
+    ox = pd.to_numeric(frame['oxidation'], errors='coerce')
+    if not ox.notna().any():
+        return series  # no input oxidation -> keep the type/gas-capture default
+
+    # 1) Site-wide mean as the full-series baseline.
+    series[:] = float(ox[ox.notna()].mean())
+
+    # 2) Overwrite individual years where an emissions year ties a value to a year.
+    if 'reported_emissions_year' in frame.columns:
+        yr = pd.to_numeric(frame['reported_emissions_year'], errors='coerce')
+        mask = ox.notna() & yr.notna()
+        if mask.any():
+            per_year = pd.Series(ox[mask].to_numpy(), index=yr[mask].astype(int).to_numpy())
+            per_year = per_year.groupby(level=0).mean()
+            lo, hi = int(years_index.min()), int(years_index.max())
+            per_year = per_year[(per_year.index >= lo) & (per_year.index <= hi)]
+            if not per_year.empty:
+                series.loc[per_year.index] = per_year.to_numpy()
+
+    return series
+
+
 # The way this model is set up is based on the unit of a City, corresponding to the City class.
 # Cities can have multiple sets of CityParameters, one for each scenario.
 # Sets of CityParameters can have one or more landfills, dumpsites, waste to energy, etc.
@@ -2486,6 +2544,9 @@ class City:
             )
         fraction_of_waste_vector.loc[open_date:close_date-1] = 1.0
         id = int(canonical_row['asset_identifier'])
+        oxidation_series = _build_oxidation_series(
+            oxidation_value, canonical_row, time_series_rows, self.years_range
+        )
         new_landfill = Landfill(
             open_date=open_date,
             close_date=close_date,
@@ -2506,7 +2567,7 @@ class City:
             advanced=True,
             latlon=(self.latitude, self.longitude),
             ks=baseline.ks,
-            oxidation_factor=pd.Series(oxidation_value, index=self.years_range),
+            oxidation_factor=oxidation_series,
             rmi_id=id,
         )
         baseline.landfills.append(new_landfill)
@@ -2755,6 +2816,9 @@ class City:
                 close_date = int(close_date)
 
         id = int(canonical_row['asset_identifier'])
+        oxidation_series = _build_oxidation_series(
+            oxidation_value, canonical_row, time_series_rows, self.years_range
+        )
         baseline._singapore_k(advanced_baseline=True)
         if (citysite_rows is None) or (isinstance(citysite_rows, pd.Series)):
             fraction_of_waste_vector = pd.Series(
@@ -2781,7 +2845,7 @@ class City:
                 advanced=True,
                 latlon=(self.latitude, self.longitude),
                 ks=baseline.ks,
-                oxidation_factor=pd.Series(oxidation_value, index=self.years_range),
+                oxidation_factor=oxidation_series,
                 rmi_id=id,
                 city_id=citysite_rows['city_id']
             )
@@ -2876,7 +2940,7 @@ class City:
                     advanced=True,
                     latlon=(self.latitude, self.longitude),
                     ks=baseline.ks,
-                    oxidation_factor=pd.Series(oxidation_value, index=self.years_range),
+                    oxidation_factor=oxidation_series,
                     rmi_id=id,
                     city_id=city_id,
                 )

--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -53,9 +53,12 @@ def _build_oxidation_series(default_value, canonical_row, time_series_rows, year
 
     # Assemble the site's input rows as a frame so single-row (Series) and multi-row
     # (DataFrame) sites are handled uniformly. Prefer the multi-row frame -- it holds
-    # every source record -- and fall back to the single canonical row.
+    # every source record -- then the single-row time_series_rows (documented Series
+    # case), and finally the single canonical row.
     if isinstance(time_series_rows, pd.DataFrame):
         frame = time_series_rows
+    elif isinstance(time_series_rows, pd.Series):
+        frame = time_series_rows.to_frame().T
     elif isinstance(canonical_row, pd.DataFrame):
         frame = canonical_row
     elif isinstance(canonical_row, pd.Series):

--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -2547,6 +2547,12 @@ class City:
         oxidation_series = _build_oxidation_series(
             oxidation_value, canonical_row, time_series_rows, self.years_range
         )
+        # Baseline flaring destruction efficiency, set explicitly to the canonical default
+        # (was unset -> fell to model_v2's internal default). No per-site source exists;
+        # mitigation raises it to 0.98/0.99 via _gccs_flaring (max/clip). Local import
+        # avoids the dst_common <-> city_params import cycle.
+        from SWEET_python.dst_common import DEFAULT_FLARE_EFFICIENCY
+        flaring_series = pd.Series(DEFAULT_FLARE_EFFICIENCY, index=self.years_range)
         new_landfill = Landfill(
             open_date=open_date,
             close_date=close_date,
@@ -2561,7 +2567,7 @@ class City:
             scenario=0,
             new_baseline=True,
             gas_capture_efficiency=gas_capture_efficiency,
-            # flaring=pd.Series(flaring, index=year_range),
+            flaring=flaring_series,
             # leachate_circulate=leachate_circulate[i],
             fraction_of_waste_vector=fraction_of_waste_vector,
             advanced=True,
@@ -2819,6 +2825,11 @@ class City:
         oxidation_series = _build_oxidation_series(
             oxidation_value, canonical_row, time_series_rows, self.years_range
         )
+        # Baseline flaring destruction efficiency, set explicitly to the canonical default
+        # (see site_only_estimate_trace). Applies to both the single- and multi-city
+        # landfill constructors below. Local import avoids the dst_common import cycle.
+        from SWEET_python.dst_common import DEFAULT_FLARE_EFFICIENCY
+        flaring_series = pd.Series(DEFAULT_FLARE_EFFICIENCY, index=self.years_range)
         baseline._singapore_k(advanced_baseline=True)
         if (citysite_rows is None) or (isinstance(citysite_rows, pd.Series)):
             fraction_of_waste_vector = pd.Series(
@@ -2839,7 +2850,7 @@ class City:
                 scenario=0,
                 new_baseline=True,
                 gas_capture_efficiency=gas_capture_efficiency,
-                # flaring=pd.Series(flaring, index=year_range),
+                flaring=flaring_series,
                 # leachate_circulate=leachate_circulate[i],
                 fraction_of_waste_vector=fraction_of_waste_vector,
                 advanced=True,
@@ -2934,7 +2945,7 @@ class City:
                     scenario=0,
                     new_baseline=True,
                     gas_capture_efficiency=gas_capture_efficiency,
-                    # flaring=pd.Series(flaring, index=year_range),
+                    flaring=flaring_series,
                     # leachate_circulate=leachate_circulate[i],
                     fraction_of_waste_vector=fraction_of_waste_df[city_id],
                     advanced=True,


### PR DESCRIPTION
## Summary

Modeled landfills previously always received a **type/gas-capture default** oxidation factor (sanitary 0.10 no-capture / 0.22 with capture; controlled dump 0.05/0.10; dumpsite 0). The Climate TRACE waste-methane pipeline's input query carries a per-site `oxidation` column (populated for ~19% of sites from the standardized source table; NULL for the GPW/OSM area-matched branch) that was **never read**. This wires it in.

## What changed

`site_only_estimate_trace` and `citysite_estimate_trace` now prefer the input oxidation over the default, via a new `_build_oxidation_series(default, canonical_row, time_series_rows, years_range)` helper:

- **Site-wide mean** of the non-null input values as the full-series baseline, then a **per-year overwrite** (mean of conflicting same-year rows) keyed by `reported_emissions_year` where present — mirrors the existing `gas_collection_efficiency` handling one block below.
- **No input → the prior type/gas-capture default**, broadcast across all years (unchanged for the ~81% of sites without a measured value).
- Values are used **as-is (no clamping)** — a measured 0.35 passes through; the 0.25 biocover clamp is dead code (`doing_fancy_ox` is hardcoded `False`) and does not apply here.

The legacy WasteMAP builders (`site_only_estimate`, `sinar_city_and_site`) are intentionally left on defaults — they use a different row schema and are not on the Climate TRACE modeled-site path.

## Model-output change (not breaking)

Emissions shift for the ~19% of sites with a measured oxidation; higher oxidation destroys more CH₄, so those sites model lower emissions. No API/schema/contract change.

## Testing

- New `RMI_Climate_TRACE_Waste_Methane/tests/manual/test_input_oxidation.py`: helper logic (mean baseline, per-year overwrite, conflicting-same-year averaging, unclipped 0.35, out-of-range years, no-input fallback) + end-to-end baseline (default 0.10 / 0.22, input 0.35 propagates, higher oxidation lowers emissions).
- SWEET test suite (86) and the RMI manual mitigation suite (106) pass against this change.

## Definition of done

- [x] Input oxidation preferred over the type/gas-capture default; default retained as fallback.
- [x] Tests pass (SWEET suite; RMI manual + smoke/unit).
- [ ] Reviewed & merged (paired with the RMI PR below).

## Paired PR

Consumed by RMI/RMI_Climate_TRACE_Waste_Methane#74 (same `ers-update` branch), which carries the value through to the mitigation stage and adds `max(existing, new)` oxidation semantics to the ERS strategies.

## Flaring baseline (added — explicit default)

Also sets each modeled landfill's flaring destruction efficiency **explicitly** to `dst_common.DEFAULT_FLARE_EFFICIENCY` (0.98) in `site_only_estimate_trace` / `citysite_estimate_trace`, instead of leaving it unset and relying on `model_v2`'s internal default. There is **no per-site flaring-efficiency source** (only flared volumes + a `has_flaring` boolean), so 0.98 is the canonical default; mitigation raises it to 0.98/0.99 for the few improve-GCCS strategies via `_gccs_flaring`'s floor (max/clip). **No TRACE output change** — numerically identical to the prior monthly default. `model_v2`'s annual-vs-monthly default inconsistency (1.0 vs 0.98) was left untouched (TRACE never uses the annual path; changing it would shift WasteMAP output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Review responses (Copilot / andre)

- **The default-broadcast fallback in `_build_oxidation_series` is intentional, and now documented** (`de1ef58`). It serves callers whose input frame carries no per-year `oxidation` column — the older city DST / `make_cities_table` path, which predates per-year oxidation and supplies a single baseline value. The Climate TRACE **sites and cities** pipelines both `SELECT oxidation` into their multi-row frames, so measured oxidation *is* used there; this only defaults when the column is genuinely absent. (This "time-series for sites / single value for cities" switch is the reason several `isinstance(..., Series/DataFrame)` branches exist here.)
- **Single-row `time_series_rows` (a `Series`) is now honored** (`7e7d1ef`): the branch chain previously skipped it and fell to `canonical_row`. Added the `Series` branch so a single-row site's own `time_series_rows` oxidation is used, matching the docstring. Harmless in the TRACE pipelines (multi-row `DataFrame` path, or `canonical_row` carries the same value), but removes the code/docstring mismatch Copilot flagged.

## Merge note

Deploy pairs with **RMI/RMI_Climate_TRACE_Waste_Methane#74** by branch name (`ers-update`). Merge/land the two together.
