### PR TITLE
Fix leap-year Oct/Dec notch in the monthly FOD decay mask

### DIFF
--- a/SWEET_python/model_v2.py
+++ b/SWEET_python/model_v2.py
@@ -264,10 +264,23 @@ class SWEET:
             half_year_offset = 0.5 * ks_monthly[None, :]  # k at deposit month
             integral_adjusted = integral - half_year_offset
             
-            # Mask out emissions where integral_adjusted <= 0
-            # This is analogous to the annual model's mask for years_back <= 0
-            # (no emissions until ~0.5 years after deposit)
-            mask_positive_integral = integral_adjusted > 0
+            # Mask out deposits younger than the ~half-year emission lag (analogous
+            # to the annual model's years_back <= 0 mask: no emission until ~0.5 yr
+            # after deposit). The cutoff is integral_adjusted == 0 (deposit exactly
+            # half a year old). In a LEAP year the monthly grid lands EXACTLY on that
+            # cutoff for the deposit six months before a 31-day emission month
+            # (Jun->Dec, Apr->Oct: 183/366 == 0.5), whereas in a common year it lands
+            # just past it (183/365 == 0.50137). integral_adjusted is a difference of
+            # two O(k) cumulative sums, so at the cutoff it is 0 +/- ~1e-15
+            # (catastrophic cancellation) and a bare `> 0` (or `>= 0`) includes/drops
+            # that whole deposit-month unpredictably -> a spurious ~1-2% Oct/Dec notch
+            # in leap years only. Use a tolerance well below any real k-time step
+            # (genuine "just past cutoff" values are ~1e-4..1e-3) but above FP noise,
+            # so the exact-half-year deposit is retained consistently in leap and
+            # common years. Within-year redistribution; leap-year annual rises by the
+            # physically-real extra-day mass (~+0.25%), common years unchanged.
+            _HALF_YEAR_TOL = 1e-9
+            mask_positive_integral = integral_adjusted >= -_HALF_YEAR_TOL
             decay = np.exp(-integral_adjusted)
             decay[~mask_valid] = 0
             decay[~mask_positive_integral] = 0


### PR DESCRIPTION
## Summary

Fixes a leap-year artifact in SWEET's monthly first-order-decay kernel (`estimate_emissions_monthly`) that produced a spurious ~1–2% dip in the 31-day peak months (October, December) of **modeled** sites, in leap years only. It surfaced as Climate TRACE QA **"de-trended z-score > 3"** flags on smoothly-growing modeled countries at **Oct-2020 and Dec-2020** (e.g. Bangladesh, Cameroon), traced by the diagnostic in the paired RMI PR (see below).

## Bug

- **Component:** `SWEET_python/model_v2.py` → `SWEET.estimate_emissions_monthly` (the modeled-site monthly path; reported/single-value sites don't use it).
- **Reproduction:** any modeled site's monthly CH4 series shows Oct/Dec sitting below their own per-calendar-month trend in leap years (2016/2020/2024), with February correspondingly elevated. On a per-calendar-month linear fit, leap-year Oct/Dec are >3σ outliers.
- **Expected:** the monthly profile should be leap-invariant apart from the genuine calendar effects (Feb's real 29th day; the ~0.27% shorter day-share of a 31-day month in a 366-day year).
- **Actual:** an extra ~1–2% notch in Oct/Dec in leap years, unrelated to any input or physical effect.

## Root cause

The kernel masks deposits younger than the ~half-year emission lag with a **strict** `integral_adjusted > 0` (L270). The cutoff is `integral_adjusted == 0` (deposit exactly 0.5 yr old). In a **leap** year the monthly grid lands *exactly* on it for the deposit six months before a 31-day emission month (Jun→Dec, Apr→Oct: `183/366 == 0.5`); in a common year it lands just past (`183/365 == 0.50137`). Since `integral_adjusted` is a difference of two O(k) cumulative sums, at the cutoff it evaluates to `0 ± ~1e-15` (catastrophic cancellation) — so a bare `> 0` (and, as tested, a bare `>= 0`) includes/drops that whole deposit-month unpredictably, notching Oct/Dec in leap years. September (`184/366 = 0.5027`) never grid-aligns → no notch (confirming null).

## Fix

Mask with a small tolerance: `integral_adjusted >= -1e-9`. The tolerance is far below any real k-time step (genuine just-past-cutoff values are ~1e-4…1e-3) but above FP noise, so the exact-half-year deposit is retained consistently in leap and common years.

## Impact — `model-output-change`

Within-year redistribution; **common years are bit-for-bit unchanged**. In leap years:
- The monthly profile is smoothed — the Oct/Dec notch closes to the ~0.2% genuine 365-vs-366-day floor (which is physically correct and remains).
- **Leap-year ANNUAL totals rise by the physically-real extra-day mass: ~+0.25%** (normal-k) to **+0.36%** (BGD-like hot/wet growing site). This corrects a pre-existing ~0.25% *under*-count in leap years (the notch was cancelling the extra-day mass). Submitted annual values for 2016/2020/2024 will move up by that amount; 2015/2017/2018/2019/2021/… are unchanged.

Only modeled sites are affected; reported/single-value city paths use a flat `annual/12` split and are untouched.

## Validation

Ran the real kernel (DB-free `City.site_only_estimate_trace` → `estimate_emissions_monthly`), UNFIXED vs fixed, on constant-waste normal-k (k≈0.17) and fast-k (k≈0.69) sites and a **BGD-like** site built from asset 13169's actual parquet inputs (25.8 °C / 1955 mm, dumpsite, open 1990, growing waste reproduced to the ton):

| site | Oct/Dec-2020 notch UNFIXED | fixed | leap-2020 annual Δ | common-year Δ |
|---|---|---|---|---|
| normal k≈0.17 | −1.66% | −0.21% | +0.248% | 0 (bit-identical) |
| fast k≈0.69 | −0.20% (no mask-notch) | −0.20% | +0.000% | 0 |
| BGD-like k≈0.24 | −2.36% | −0.26% | +0.364% | 0 |

Whole-series diff (every month 2000–2050): the **only** cells that change are leap-year October and December, all additive; zero non-leap and zero other-calendar-month movement.

## Acceptance Criteria

- [x] Leap-year Oct/Dec notch closes across k regimes (to the genuine days-in-year floor).
- [x] Common years bit-for-bit unchanged; only leap-year Oct/Dec cells move (all additive).
- [x] Leap-year annual change equals the physically-real extra-day mass (~+0.25%), documented as `model-output-change`.
- [x] No new artifacts (the tolerance is a systematic correction, not the FP one-off of a bare `>= 0`).

## Definition of Done

- [x] Acceptance criteria met
- [x] Independently validated against the real kernel (numbers above)
- [x] Root cause documented in-code
- [ ] Reviewed & merged (paired with the RMI diagnostic PR)

**Cross-repo pairing:** branch `country-exceedance-source-trace`, paired with `RMI_Climate_TRACE_Waste_Methane` PR #78 (the `country_exceedance_trace.py` diagnostic that surfaced and traced this). Please review/merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
