### PR TITLE
Modelled sites with gas capture data but no reported emissions get their site-type capture default, not NaN

### DIFF
--- a/SWEET_python/city_params.py
+++ b/SWEET_python/city_params.py
@@ -2503,9 +2503,30 @@ class City:
                 oxidation_value = ox_options["ox_nocap"][site_type]
         
         if isinstance(time_series_rows, pd.DataFrame):
+            gascap_df = None
             if time_series_rows['gas_collection_efficiency'].notna().any():
+                # Measured per-year capture is keyed on reported_emissions_year, so a row
+                # without one cannot be placed. Drop on BOTH columns: a row can carry a
+                # reported year with no capture value, or a capture value with no year.
+                #
+                # The all-dropped case is reachable and is not an edge case. The TRACE
+                # input query selects gas_collection_efficiency independently of
+                # CH4_reported, and reported_emissions_year is DERIVED from CH4_reported
+                # (landfill_table_ops.py: extract_emissions_year_from_dict). A site with
+                # capture data but no reported emissions therefore has no reported year at
+                # all -- and, because a null CH4_reported is exactly what routes a site to
+                # 'to be modeled', such a site reaches this branch rather than the reported
+                # pathway. Taking .mean() of the emptied frame yielded NaN and poisoned the
+                # whole capture series; fall back to the site-type default instead, matching
+                # the scalar path below.
                 gascap_df = time_series_rows[['reported_emissions_year', 'gas_collection_efficiency']]
-                gascap_df = gascap_df.dropna(subset=['reported_emissions_year']).copy()
+                gascap_df = gascap_df.dropna(
+                    subset=['reported_emissions_year', 'gas_collection_efficiency']
+                ).copy()
+                if gascap_df.empty:
+                    gascap_df = None
+
+            if gascap_df is not None:
                 gas_capture_efficiency_mean = gascap_df['gas_collection_efficiency'].mean()
                 gas_capture_efficiency = pd.Series(gas_capture_efficiency_mean, index=self.years_range)
                 gas_capture_efficiency.loc[gascap_df['reported_emissions_year'].values] = gascap_df['gas_collection_efficiency'].values


### PR DESCRIPTION
## Summary

A landfill that carries `gas_collection_efficiency` but has **no reported emissions** ended up with an all-NaN gas capture efficiency series instead of falling back to its site-type default. This restores the fallback.

## Environment

- Component: `SWEET_python/city_params.py`, `site_only_estimate_trace` (the Climate TRACE sites path)
- Consumer: `RMI_Climate_TRACE_Waste_Methane` `pipeline_runner` Section 3 (SWEET modelling)
- Affects the multi-row (`time_series_rows` is a `DataFrame`) branch only. The scalar/cities path was already correct.

## Reproduction

A site reaches the broken state when **both** hold:

1. At least one input row has a non-null `gas_collection_efficiency`; and
2. No input row has a `reported_emissions_year`.

Those co-occur more readily than it looks. The TRACE input query selects `gas_collection_efficiency` independently of `CH4_reported` (`landfill_table_ops.py:153`), while `reported_emissions_year` is *derived* from `CH4_reported` (`landfill_table_ops.py:1961`, `extract_emissions_year_from_dict`). And a null `CH4_reported` is exactly what routes a site to `emissions_estimation_method == 'to be modeled'` — i.e. into `to_model_ids`, which is the population that runs through `site_only_estimate_trace`. **The modelled pathway is the one that hits the bug.**

Minimal repro of the control flow:

```python
ts = pd.DataFrame({
    "reported_emissions_year": [np.nan, np.nan],
    "gas_collection_efficiency": [0.55, 0.55],
})
# guard passes: .notna().any() is True
# dropna(subset=["reported_emissions_year"]) -> empty frame
# .mean() of empty -> NaN -> the whole capture series is NaN
```

## Expected vs actual

| input | expected | actual (before) |
|---|---|---|
| capture data, no reported year | site-type default (Sanitary 0.6 / Controlled Dumpsite 0.45 / Dumpsite 0.0) | **all-NaN series** |
| capture keyed to a reported year | the measured value | the measured value (correct) |
| reported year present, capture null on that row | site-type default | **all-NaN series** |

The third row is a second, narrower route to the same NaN that the original report did not cover: the frame survives the `dropna` but every surviving `gas_collection_efficiency` is null, so `.mean()` is still NaN. This PR drops on both columns.

Verified after the change:

```
capture data, no reported year   ->  0.6   (was all-NaN)
capture keyed to a reported year ->  0.72  (unchanged - measured value still wins)
reported year, null capture      ->  0.6   (was NaN)
```

## Why the fallback is the right answer

The scalar path immediately below this block already did exactly this — `if pd.isna(gas_capture_efficiency): gas_capture_efficiency = gas_eff_options[site_type]`. The two branches now agree, which is the invariant that was broken.

## Blast radius

`model-output-change`, not `breaking-change` — nothing stops running. Affected sites previously carried a NaN capture efficiency into the FOD model; they will now carry their type default and produce different (correct) emissions.

## Counting the affected sites

The count comes off the pipeline's own blob artifacts — no database query, and nothing from the consumer repo needs importing here (SWEET is the dependency; it cannot import `RMI_Climate_TRACE_Waste_Methane`). Plain `pandas` on a saved file is enough.

Use **`outputs/landfills.parquet`**. It is the multi-row landfill frame exactly as `pipeline_runner` receives it from `load_landfills_table()` and slices per site into `time_series_rows`, so its rows are the rows this branch reasons about — one per asset × source/year, capture values un-deduplicated. It already carries every column needed: `asset_identifier`, `gas_collection_efficiency`, `reported_emissions_year` (derived before the save), and `CH4_reported`.

```python
import pandas as pd

lf = pd.read_parquet("outputs/landfills.parquet")

g = lf.groupby("asset_identifier")
has_gccs = g["gas_collection_efficiency"].apply(lambda s: s.notna().any())
has_year = g["reported_emissions_year"].apply(lambda s: s.notna().any())
# a site is modelled (runs SWEET) when no row carries reported emissions
modelled = g["CH4_reported"].apply(lambda s: s.isna().all())

# a row is usable only if it carries BOTH a year to key on and a capture value
usable_ids = lf.dropna(subset=["reported_emissions_year", "gas_collection_efficiency"])["asset_identifier"].unique()
affected = has_gccs & ~has_gccs.index.isin(usable_ids)

print(f"sites with capture data:        {int(has_gccs.sum())}")
print(f"  ...no usable (year, capture) row: {int(affected.sum())}   <- affected")
print(f"  ...breakdown, no reported year:   {int((has_gccs & ~has_year).sum())}")
print(f"  ...of those, modelled sites:      {int((affected & modelled).sum())}")
```

The last line is the number that sizes the label: a site with `CH4_reported` takes the reported-emissions projection instead of the FOD path, so its capture series never reaches the model even when it is NaN.

Two cross-checks against other artifacts, if wanted:

- The **published asset file** carries `other4 = emissions_estimation_method` and `other5 = reported_emissions_year`, so "modelled, no reported year" is confirmable there without any intermediate.
- **`outputs/assets_before_satellite.parquet`** (one canonical row per asset) also keeps `gas_collection_efficiency` alongside `emissions_estimation_method`. Good for a sanity check on totals, but it is post-dedup — it cannot express "reported year present on a row that has no capture value", which is why the per-row frame above is the right source.

For a past submission, the archived equivalent is `input.parquet`, which is also multi-row but is dumped straight off the SQL query, i.e. before the column rename and before `reported_emissions_year` is derived. There it is `emissions_metric_tons` and the raw `year` dict, and the reported year has to be re-derived (`year['emissions_year']` when present, else the mode of the dict's numeric values, and only for rows with positive reported emissions). `outputs/landfills.parquet` is simply the same data after that step, so prefer it when the run is current.

## Acceptance criteria

- [x] A modelled site with capture data and no reported emissions year gets its site-type default, not NaN
- [x] A site with a measured capture value keyed to a reported year is unchanged
- [x] A row carrying a reported year but a null capture value cannot produce a NaN mean
- [x] The `DataFrame` branch and the scalar branch agree on the fallback
- [ ] Affected-site count measured against `outputs/landfills.parquet` from a recent run (needs a blob copy; not blocking)

## Definition of done

- [x] Acceptance criteria met
- [x] `city_params.py` compiles; downstream `pytest tests/smoke tests/unit` in `RMI_Climate_TRACE_Waste_Methane` is green (246 passed, 1 skipped)
- [x] Rationale documented in the code comment, including why the all-dropped case is reachable rather than defensive
- [ ] Reviewed & merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
