### PR TITLE
Cover oxidation applies by emission year, so biocover reduces emissions on closed landfills

### DIFF
--- a/SWEET_python/model_v2.py
+++ b/SWEET_python/model_v2.py
@@ -156,9 +156,25 @@ class SWEET:
                 * flare_efficiency.loc[year_range].values
             )
 
-            # Final methane emissions calculation with oxidation
+            # Final methane emissions calculation with oxidation.
+            #
+            # ch4_produce/ch4_capture are (deposit_year, emission_year) matrices
+            # (row i = deposit year, column j = emission year; summed over axis=0
+            # to give per-emission-year totals). Cover oxidation happens as gas
+            # migrates out through the cover, so it is a property of the EMISSION
+            # year, not the deposit year -- exactly like gas capture and flaring
+            # above, which broadcast their (n,) vectors across columns (emission
+            # year). Oxidation must broadcast the same way: index by column j via
+            # [None, :]. The previous [:, None] indexed by row i (deposit year),
+            # so a time-varying oxidation change at an implementation year (e.g.
+            # biocover, an oxidation override, or a landfill-type change) was
+            # applied to waste *deposited* from that year on rather than to
+            # methane *emitted* from that year on. For a closed landfill (no new
+            # deposits) that meant the change had no effect at all -- the
+            # "biocover does not reduce emissions" bug (WasteMAP #719). This also
+            # matches the monthly model, which already oxidises by emission month.
             ch4_year_total = np.sum(
-                (ch4_produce - ch4_capture) * (1 - oxidation_factor_values[:, None])
+                (ch4_produce - ch4_capture) * (1 - oxidation_factor_values[None, :])
                 + ch4_capture * 0.02,
                 axis=0,
             )

--- a/changelog/2026-08.md
+++ b/changelog/2026-08.md
@@ -1,10 +1,28 @@
 # SWEET_python Changelog — August 2026
 
-**Highlights:** The single-site advanced DST (`advanced_dst`) gains two optional inputs — `depth` and `k_override` — that restore the last two site-DST (`City.sdst_v1_5`) levers the adst model had no equivalent for. Both default to "derive as before," so existing adst calls are byte-for-byte unaffected; they are opt-in and not a model-output change for current callers. Separately, a variable-name bug in `City.sdst_v1_5` was silently discarding the `/sdst` flaring efficiency and forcing flare destruction to the 0.98 default on every run. Sites that set a non-default flaring efficiency now model the value the user supplied. This is a model-output change for any sdst run with a non-0.98 flaring efficiency.
+**Highlights:** The single-site advanced DST (`advanced_dst`) gains two optional inputs — `depth` and `k_override` — that restore the last two site-DST (`City.sdst_v1_5`) levers the adst model had no equivalent for. Both default to "derive as before," so existing adst calls are byte-for-byte unaffected; they are opt-in and not a model-output change for current callers. Separately, a variable-name bug in `City.sdst_v1_5` was silently discarding the `/sdst` flaring efficiency and forcing flare destruction to the 0.98 default on every run. Sites that set a non-default flaring efficiency now model the value the user supplied. This is a model-output change for any sdst run with a non-0.98 flaring efficiency. Also, the annual model (`estimate_emissions2`) now applies cover oxidation by emission year rather than deposit year, so a mid-life oxidation change (e.g. biocover) affects methane emitted from that year on — fixing biocover having no effect on already-closed landfills (WasteMAP #719). This is a model-output change for scenarios that vary oxidation over time; constant-oxidation runs are unchanged.
 
 ## Added
 - `AdvancedDSTRequest.depth` (`Optional[Variant[float]]`, metres): a controlled or open dump (landfill type 1 or 2) deeper than 5 m has its methane correction factor raised to 0.8, matching `City.sdst_v1_5`'s deep-dump rule (deep dumps decompose more anaerobically). Implemented in `dst_common.mcf_series`, which now accepts optional per-variant `baseline_depth`/`scenario_depth`; a `None` depth (the default) leaves MCF at the per-type value, and the rule never applies to engineered landfills (type 0). Restores the `/sdst` "Depth" control for adst. ([#40](https://github.com/RMI/SWEET_python/pull/40))
 - `AdvancedDSTRequest.k_override` (`Optional[Variant[YearlyFloat]]`): a per-year decomposition rate `k` that, when supplied, is applied uniformly to every biodegradable component and bypasses the derived (temperature/precipitation/composition) k — mirroring `City.sdst_v1_5`'s `ks_overrides`. Implemented via the new `dst_common.uniform_decomposition_rates` helper; spliced at `implement_year` like every other adst scenario input. Restores the `/sdst` "Degradation rate (k)" control for adst. ([#40](https://github.com/RMI/SWEET_python/pull/40))
 
 ## Fixed
+- `model_v2.SWEET.estimate_emissions2` now applies cover oxidation by **emission
+  year**, not deposit year. The method builds `(deposit_year, emission_year)`
+  methane matrices and sums over deposit years; gas capture and flaring already
+  broadcast their `(n,)` vectors across columns (emission year), but oxidation
+  used `oxidation_factor_values[:, None]`, indexing by row (deposit year). Cover
+  oxidation acts on methane as it migrates out through the cover, so it is a
+  property of the emission year (matching the IPCC 2006 FOD convention and the
+  monthly model `estimate_emissions_monthly`). Indexing by deposit year meant a
+  time-varying oxidation change at an implementation year — biocover, an
+  oxidation override, or a landfill-type change — was applied to waste *deposited*
+  from that year on rather than to methane *emitted* from that year on; for a
+  landfill that had already closed there was no such waste, so the change had no
+  effect at all (the "biocover does not reduce emissions" bug, WasteMAP #719).
+  Now `oxidation_factor_values[None, :]`. **Model-output change:** any run with a
+  time-varying oxidation factor (site/city DST scenarios) will now produce
+  different (correct) results; runs with a constant oxidation factor are
+  byte-for-byte unchanged. Adds `tests/test_model_v2_oxidation_emission_year.py`.
+  ([#44](https://github.com/RMI/SWEET_python/pull/44))
 - `City.sdst_v1_5` now reads the caller-supplied flaring efficiency again. The flaring block referenced an undefined bare name `flaring` (the endpoint parameter is `new_landfill_flaring`); the resulting `NameError` was swallowed by a bare `except`, so flare destruction was always forced to the 0.98 default and the user's input was ignored. The block now reads `new_landfill_flaring[...][0]` per landfill (sdst models a single landfill, index 0), falling back to `DEFAULT_FLARE_EFFICIENCY` only when no value is supplied. **Model-output change:** any sdst run that set a non-0.98 flaring efficiency will now produce different (correct) results. ([#41](https://github.com/RMI/SWEET_python/pull/41))

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,7 +15,7 @@ The project does not publish semantic version tags, so releases are tracked by
 
 Newest first:
 
-- [2026-08](2026-08.md) — Single-site adst gains optional `depth` (deep-dump MCF bump) and `k_override` (caller-supplied decomposition rate) inputs, restoring the last two site-DST levers; `/sdst` flaring efficiency reaches the model again after a variable-name bug silently forced flare destruction to 0.98 (model-output change)
+- [2026-08](2026-08.md) — Single-site adst gains optional `depth` (deep-dump MCF bump) and `k_override` (caller-supplied decomposition rate) inputs, restoring the last two site-DST levers; `/sdst` flaring efficiency reaches the model again after a variable-name bug silently forced flare destruction to 0.98; annual model applies cover oxidation by emission year not deposit year, fixing biocover having no effect on closed landfills (WasteMAP #719) (model-output change)
 - [2026-07](2026-07.md) — All ten waste types eligible for combustion (metal/glass/other added); methane-only model treats combustion as landfill diversion (model-output change)
 - [2026-06](2026-06.md) — New single-site and city-level ADST modeling modules, min-cost max-flow rewrite of the city DST diversion allocator, physical-k fix for cold/dry sites, no more spurious negative food-waste mass
 - [2026-05](2026-05.md) — SDST models from a landfill's actual open year (1950–2050), Central Asia/Afghanistan disposal-default fix, auto-Jira issue tooling, professional-comment cleanup

--- a/tests/test_model_v2_oxidation_emission_year.py
+++ b/tests/test_model_v2_oxidation_emission_year.py
@@ -1,0 +1,99 @@
+"""Regression tests for cover-oxidation being applied by EMISSION year.
+
+WasteMAP issue #719 ("Bio cover in site DST not working properly"): raising the
+oxidation factor from an implementation year on (e.g. installing biocover) must
+reduce methane *emitted* from that year on, regardless of when the waste was
+deposited. The annual model previously applied oxidation along the deposit-year
+axis, so for a landfill that had already closed there was no post-implementation
+deposited waste for the higher oxidation to act on and the change had no effect.
+"""
+import pandas as pd
+import pytest
+
+from SWEET_python.model_v2 import SWEET
+
+COMPONENTS = ["food", "green", "wood", "paper_cardboard", "textiles"]
+
+
+def _run(open_date, close_date, oxidation_factor):
+    """Run estimate_emissions2 for a single landfill with a given oxidation series."""
+    years = pd.Index(range(open_date, 2051))
+    if not isinstance(oxidation_factor, pd.Series):
+        oxidation_factor = pd.Series(oxidation_factor, index=years)
+    # Waste is only deposited while the landfill is open.
+    waste = pd.DataFrame(0.0, index=years, columns=COMPONENTS)
+    waste.loc[open_date:close_date, :] = 1000.0
+    landfill_attrs = {
+        "open_date": open_date,
+        "close_date": close_date,
+        "ks": {c: pd.Series(0.2, index=years) for c in COMPONENTS},
+        "waste_mass_df": waste,
+        "mcf": pd.Series(1.0, index=years),
+        "gas_capture_efficiency": pd.Series(0.0, index=years),
+        "oxidation_factor": oxidation_factor,
+        "flaring": pd.Series(0.98, index=years),
+    }
+    model = SWEET(
+        city_instance_attrs={"components": COMPONENTS},
+        city_params_dict={
+            "year_of_data_pop": 2025,
+            "growth_rate_historic": 1.0,
+            "growth_rate_future": 1.0,
+        },
+        landfill_instance_attrs=landfill_attrs,
+    )
+    _, emissions, _, _ = model.estimate_emissions2()
+    return emissions
+
+
+def _step_oxidation(open_date, low, high, implement_year):
+    years = pd.Index(range(open_date, 2051))
+    series = pd.Series(low, index=years)
+    series.loc[implement_year:] = high
+    return series
+
+
+def test_biocover_reduces_emissions_from_a_closed_landfill():
+    """The #719 case: landfill closed in 2011, biocover raises oxidation to 0.9
+    starting 2025. Emissions after 2025 must fall even though no waste is
+    deposited after 2011."""
+    open_date, close_date, implement = 1990, 2011, 2025
+    base = _run(open_date, close_date, 0.1)
+    biocover = _run(
+        open_date,
+        close_date,
+        _step_oxidation(open_date, 0.1, 0.9, implement),
+    )
+
+    # Before the implementation year the two runs are identical.
+    assert biocover.loc[2020, "total"] == pytest.approx(base.loc[2020, "total"])
+
+    # From the implementation year on, emitted methane is oxidised at 0.9 instead
+    # of 0.1: emission = ch4 * (1 - ox). No gas capture, so the ratio is exact.
+    assert base.loc[2030, "total"] > 0
+    assert biocover.loc[2030, "total"] == pytest.approx(
+        base.loc[2030, "total"] * (1 - 0.9) / (1 - 0.1)
+    )
+    assert biocover.loc[2030, "total"] < base.loc[2030, "total"]
+
+
+def test_oxidation_is_applied_by_emission_year_not_deposit_year():
+    """A step change in oxidation at an implementation year affects every
+    emission year >= that year, independent of deposit year."""
+    ox = _step_oxidation(1990, 0.1, 0.5, 2025)
+    emissions = _run(1990, 2050, ox)
+    flat_low = _run(1990, 2050, 0.1)
+    flat_high = _run(1990, 2050, 0.5)
+
+    # Year before the step matches the low-oxidation run; year at/after the step
+    # matches the high-oxidation run -- i.e. keyed on emission year.
+    assert emissions.loc[2024, "total"] == pytest.approx(flat_low.loc[2024, "total"])
+    assert emissions.loc[2025, "total"] == pytest.approx(flat_high.loc[2025, "total"])
+    assert emissions.loc[2030, "total"] == pytest.approx(flat_high.loc[2030, "total"])
+
+
+def test_constant_oxidation_is_unchanged():
+    """Guard: when oxidation does not vary over years the result is unaffected by
+    the emission-year fix (a constant series broadcasts identically either way)."""
+    emissions = _run(1990, 2050, 0.1)
+    assert emissions.loc[1991, "total"] == pytest.approx(107657.55599791845)


### PR DESCRIPTION
## What & why

Fixes the model-side root cause of [WasteMAP #719](https://github.com/RMI/WasteMAP/issues/719) — "Bio cover in site DST not working properly. Adding biocover does not decrease emission for the scenario."

`model_v2.SWEET.estimate_emissions2` builds per-component `(deposit_year, emission_year)` methane matrices (row `i` = deposit year, column `j` = emission year; summed over `axis=0` to give per-emission-year totals). Gas capture and flaring already broadcast their `(n,)` vectors across **columns** (emission year), but cover oxidation used `oxidation_factor_values[:, None]` — indexing by **row** (deposit year).

Cover oxidation happens as methane migrates out through the cover, so it is a property of the **emission** year. Indexing by deposit year meant a time-varying oxidation change at an implementation year — biocover, an oxidation override, or a landfill-type change — was applied to waste *deposited* from that year on rather than to methane *emitted* from that year on. For a landfill that had already closed there is no post-implementation deposited waste, so the higher oxidation had nothing to act on and the change had **zero** effect — the reported bug.

The fix broadcasts oxidation across columns (emission year), matching gas capture, flaring, and the monthly model (`estimate_emissions_monthly`, which already oxidises by emission month), and the IPCC 2006 FOD convention (Vol.5 Ch.3 Eq.3.1, where `OX(T)` is indexed by the inventory/emission year).

```diff
- (ch4_produce - ch4_capture) * (1 - oxidation_factor_values[:, None])
+ (ch4_produce - ch4_capture) * (1 - oxidation_factor_values[None, :])
```

## Model-output change

Output is **byte-for-byte unchanged** when the oxidation factor is constant over years (a constant vector broadcasts identically either way), so per-site pipeline runs and all baselines are unaffected. Output **changes** only for runs where oxidation varies over time — the site/city DST **scenario** paths (`sdst`, `adst`, `adst_city_level`). This is expected model progress, flagged `model-output-change` (not `breaking-change`: nothing stops running and the return shapes are identical).

## Verification

- New `tests/test_model_v2_oxidation_emission_year.py`: the closed-landfill biocover case (2040 emissions fall once biocover turns on), the emission-year step semantics (a step at the implementation year affects every emission year ≥ it, independent of deposit year), and a constant-oxidation invariant guard.
- Full suite: **89 passed** (86 prior + 3 new).
- Independently reviewed by a 3-perspective adversarial audit (physics/IPCC, blast radius, regression) — unanimous "correct", blast radius bounded to time-varying-oxidation DST scenarios.

## Acceptance criteria

- [x] Biocover (and any implementation-year oxidation change) reduces scenario emissions on an already-closed landfill.
- [x] Cover oxidation is applied by emission year, consistent with gas capture, flaring, and the monthly model.
- [x] Constant-oxidation runs are byte-for-byte unchanged.
- [x] Regression tests added and passing.

## Definition of Done

Acceptance criteria met · tests pass (89) · changelog updated (`changelog/2026-08.md`) · reviewed & merged. The WasteMAP side (regression test through `/v1/site_emissions/sdst_v1_5` + backend changelog) is a paired PR on a same-named branch, which WasteMAP CI matches automatically.
